### PR TITLE
trace.IsNotFound() now supports os errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,11 @@ func IsNotFound(e error) bool {
 	type nf interface {
 		IsNotFoundError() bool
 	}
-	_, ok := Unwrap(e).(nf)
+	err := Unwrap(e)
+	_, ok := err.(nf)
+	if !ok {
+		return os.IsNotExist(err)
+	}
 	return ok
 }
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -77,6 +78,10 @@ func (s *TraceSuite) TestWrapNil(c *C) {
 
 	err4 := Wrap(err3)
 	c.Assert(err4, IsNil)
+}
+
+func (s *TraceSuite) TestWrapStdlibErrors(c *C) {
+	c.Assert(IsNotFound(os.ErrNotExist), Equals, true)
 }
 
 func (s *TraceSuite) TestLogFormatter(c *C) {


### PR DESCRIPTION
`trace.IsNotFound()` was not working for `os.File` errors.