### PR TITLE
Allow creating error aggregates from channels

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -234,6 +234,21 @@ func NewAggregate(errs ...error) error {
 	return wrap(aggregate(errs), 2)
 }
 
+// NewAggregateFromChannel creates a new aggregate instance from the provided
+// errors channel.
+//
+// It is the caller's responsibility to close the channel, otherwise this
+// function might block!
+func NewAggregateFromChannel(errCh chan error) error {
+	var errs []error
+	for err := range errCh {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return NewAggregate(errs...)
+}
+
 // Aggregate interface combines several errors into one error
 type Aggregate interface {
 	error

--- a/trace.go
+++ b/trace.go
@@ -25,6 +25,8 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
+
+	"golang.org/x/net/context"
 )
 
 var debug int32
@@ -231,21 +233,37 @@ func NewAggregate(errs ...error) error {
 	if len(errs) == 0 {
 		return nil
 	}
-	return wrap(aggregate(errs), 2)
+	// filter out possible nil values
+	var nonNils []error
+	for _, err := range errs {
+		if err != nil {
+			nonNils = append(nonNils, err)
+		}
+	}
+	return wrap(aggregate(nonNils), 2)
 }
 
 // NewAggregateFromChannel creates a new aggregate instance from the provided
 // errors channel.
 //
-// It is the caller's responsibility to close the channel, otherwise this
-// function might block!
-func NewAggregateFromChannel(errCh chan error) error {
+// A context.Context can be passed in so the caller has the ability to cancel
+// the operation. If this is not desired, simply pass context.Background().
+func NewAggregateFromChannel(errCh chan error, ctx context.Context) error {
 	var errs []error
-	for err := range errCh {
-		if err != nil {
+
+Loop:
+	for {
+		select {
+		case err, ok := <-errCh:
+			if !ok { // the channel is closed, time to exit
+				break Loop
+			}
 			errs = append(errs, err)
+		case <-ctx.Done():
+			break Loop
 		}
 	}
+
 	return NewAggregate(errs...)
 }
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -250,6 +250,18 @@ func (s *TraceSuite) TestAggregateConvertsToCommonErrors(c *C) {
 	}
 }
 
+func (s *TraceSuite) TestAggregateFromChannel(c *C) {
+	errCh := make(chan error, 3)
+	errCh <- fmt.Errorf("Snap!")
+	errCh <- fmt.Errorf("BAM")
+	errCh <- fmt.Errorf("omg")
+	close(errCh)
+	err := NewAggregateFromChannel(errCh)
+	c.Assert(err.Error(), Matches, ".*Snap!.*")
+	c.Assert(err.Error(), Matches, ".*BAM.*")
+	c.Assert(err.Error(), Matches, ".*omg.*")
+}
+
 type TestError struct {
 	Traces
 	Param string


### PR DESCRIPTION
This is convenient when, for example, you need to collect errors from multiple goroutines.
