### PR TITLE
Sasha/traceback

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -70,14 +70,13 @@ func IsNotFound(e error) bool {
 // AlreadyExists returns a new instance of AlreadyExists error
 func AlreadyExists(message string, args ...interface{}) error {
 	return wrap(&AlreadyExistsError{
-		Message: fmt.Sprintf(message, args...),
+		fmt.Sprintf(message, args...),
 	}, 2)
 }
 
 // AlreadyExistsError indicates that there's a duplicate object that already
 // exists in the storage/system
 type AlreadyExistsError struct {
-	// Message is user-friendly error message
 	Message string `json:"message"`
 }
 

--- a/httplib.go
+++ b/httplib.go
@@ -62,33 +62,29 @@ func writeError(w http.ResponseWriter, err error) {
 // based on HTTP response code and HTTP body contents
 // if status code does not indicate error, it will return nil
 func ReadError(statusCode int, re []byte) error {
+	var e error
 	switch statusCode {
 	case http.StatusNotFound:
-		e := NotFoundError{}
-		return unmarshalError(&e, re)
+		e = &NotFoundError{}
 	case http.StatusBadRequest:
-		e := BadParameterError{}
-		return unmarshalError(&e, re)
+		e = &BadParameterError{}
 	case http.StatusPreconditionFailed:
-		e := CompareFailedError{}
-		return unmarshalError(&e, re)
+		e = &CompareFailedError{}
 	case http.StatusForbidden:
-		e := AccessDeniedError{}
-		return unmarshalError(&e, re)
+		e = &AccessDeniedError{}
 	case http.StatusConflict:
-		e := AlreadyExistsError{}
-		return unmarshalError(&e, re)
+		e = &AlreadyExistsError{}
 	case statusTooManyRequests:
-		e := LimitExceededError{}
-		return unmarshalError(&e, re)
+		e = &LimitExceededError{}
 	case http.StatusGatewayTimeout:
-		e := ConnectionProblemError{}
-		return unmarshalError(&e, re)
+		e = &ConnectionProblemError{}
+	default:
+		if statusCode < 200 || statusCode > 299 {
+			return Errorf(string(re))
+		}
+		return nil
 	}
-	if statusCode < 200 || statusCode > 299 {
-		return Errorf(string(re))
-	}
-	return nil
+	return unmarshalError(e, re)
 }
 
 func replyJSON(w http.ResponseWriter, code int, err error) {

--- a/httplib.go
+++ b/httplib.go
@@ -65,25 +65,25 @@ func ReadError(statusCode int, re []byte) error {
 	switch statusCode {
 	case http.StatusNotFound:
 		e := NotFoundError{}
-		return Wrap(unmarshalError(&e, re))
+		return unmarshalError(&e, re)
 	case http.StatusBadRequest:
 		e := BadParameterError{}
-		return Wrap(unmarshalError(&e, re))
+		return unmarshalError(&e, re)
 	case http.StatusPreconditionFailed:
 		e := CompareFailedError{}
-		return Wrap(unmarshalError(&e, re))
+		return unmarshalError(&e, re)
 	case http.StatusForbidden:
 		e := AccessDeniedError{}
-		return Wrap(unmarshalError(&e, re))
+		return unmarshalError(&e, re)
 	case http.StatusConflict:
 		e := AlreadyExistsError{}
-		return Wrap(unmarshalError(&e, re))
+		return unmarshalError(&e, re)
 	case statusTooManyRequests:
 		e := LimitExceededError{}
-		return Wrap(unmarshalError(&e, re))
+		return unmarshalError(&e, re)
 	case http.StatusGatewayTimeout:
 		e := ConnectionProblemError{}
-		return Wrap(unmarshalError(&e, re))
+		return unmarshalError(&e, re)
 	}
 	if statusCode < 200 || statusCode > 299 {
 		return Errorf(string(re))
@@ -137,7 +137,6 @@ func unmarshalError(err error, responseBody []byte) error {
 		}
 		return &TraceErr{Traces: raw.Traces, Err: err, Message: raw.Message}
 	}
-	// try to capture traces, if there are any
 	json.Unmarshal(responseBody, err)
 	return err
 }

--- a/log.go
+++ b/log.go
@@ -46,7 +46,7 @@ type TextFormatter struct {
 // Format implements logrus.Formatter interface and adds file and line
 func (tf *TextFormatter) Format(e *log.Entry) ([]byte, error) {
 	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(runtime.Caller(frameNo - 1))
+		t := newTrace(frameNo-1, nil)
 		new := e.WithFields(log.Fields{FileField: t.String()})
 		new.Level = e.Level
 		new.Message = e.Message
@@ -64,7 +64,7 @@ type JSONFormatter struct {
 // Format implements logrus.Formatter interface
 func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(runtime.Caller(frameNo - 1))
+		t := newTrace(frameNo-1, nil)
 		new := e.WithFields(log.Fields{
 			FileField:     t.String(),
 			FunctionField: t.Func(),

--- a/log.go
+++ b/log.go
@@ -46,8 +46,8 @@ type TextFormatter struct {
 // Format implements logrus.Formatter interface and adds file and line
 func (tf *TextFormatter) Format(e *log.Entry) ([]byte, error) {
 	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo-1, nil)
-		new := e.WithFields(log.Fields{FileField: t.String()})
+		t := newTrace(frameNo, nil)
+		new := e.WithFields(log.Fields{FileField: t.Loc(), FunctionField: t.FuncName()})
 		new.Level = e.Level
 		new.Message = e.Message
 		e = new
@@ -64,10 +64,10 @@ type JSONFormatter struct {
 // Format implements logrus.Formatter interface
 func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo-1, nil)
+		t := newTrace(frameNo, nil)
 		new := e.WithFields(log.Fields{
-			FileField:     t.String(),
-			FunctionField: t.Func(),
+			FileField:     t.Loc(),
+			FunctionField: t.FuncName(),
 		})
 		new.Level = e.Level
 		new.Message = e.Message

--- a/trace.go
+++ b/trace.go
@@ -61,6 +61,9 @@ func Unwrap(err error) error {
 
 // UserMessage returns user-friendly part of the error
 func UserMessage(err error) string {
+	if err == nil {
+		return ""
+	}
 	if wrap, ok := err.(Error); ok {
 		return wrap.UserMessage()
 	}
@@ -70,6 +73,9 @@ func UserMessage(err error) string {
 // DebugReport returns debug report with all known information
 // about the error including stack trace if it was captured
 func DebugReport(err error) string {
+	if err == nil {
+		return ""
+	}
 	if wrap, ok := err.(Error); ok {
 		return wrap.DebugReport()
 	}

--- a/trace.go
+++ b/trace.go
@@ -102,7 +102,7 @@ func wrap(err error, depth int, args ...interface{}) Error {
 // more information about the origin of error, such as
 // callee, line number and function that simplifies debugging
 func Errorf(format string, args ...interface{}) error {
-	return newTrace(1, fmt.Errorf(format, args...))
+	return newTrace(2, fmt.Errorf(format, args...))
 }
 
 // Fatalf - If debug is false Fatalf calls Errorf. If debug is
@@ -140,24 +140,24 @@ func newTrace(depth int, err error) *TraceErr {
 type Traces []Trace
 
 // SetTraces adds new traces to the list
-func (s *Traces) SetTraces(traces ...Trace) {
-	*s = append(*s, traces...)
+func (s Traces) SetTraces(traces ...Trace) {
+	s = append(s, traces...)
 }
 
 // Func returns first function in trace list
-func (s *Traces) Func() string {
-	if len(*s) == 0 {
+func (s Traces) Func() string {
+	if len(s) == 0 {
 		return ""
 	}
-	return (*s)[0].Func
+	return s[0].Func
 }
 
 // Func returns just function name
-func (s *Traces) FuncName() string {
-	if len(*s) == 0 {
+func (s Traces) FuncName() string {
+	if len(s) == 0 {
 		return ""
 	}
-	fn := filepath.ToSlash((*s)[0].Func)
+	fn := filepath.ToSlash(s[0].Func)
 	idx := strings.LastIndex(fn, "/")
 	if idx == -1 || idx == len(fn)-1 {
 		return fn
@@ -166,11 +166,11 @@ func (s *Traces) FuncName() string {
 }
 
 // Loc points to file/line location in the code
-func (s *Traces) Loc() string {
-	if len(*s) == 0 {
+func (s Traces) Loc() string {
+	if len(s) == 0 {
 		return ""
 	}
-	return (*s)[0].String()
+	return s[0].String()
 }
 
 // String returns debug-friendly representaton of trace stack
@@ -280,7 +280,7 @@ type Error interface {
 	OrigError() error
 	// AddMessage adds formatted user-facing message
 	// to the error, depends on the implementation,
-	// ususally works as fmt.Sprintf(formatArg, rest...)
+	// usually works as fmt.Sprintf(formatArg, rest...)
 	// but implementations can choose another way, e.g. treat
 	// arguments as structured args
 	AddUserMessage(formatArg interface{}, rest ...interface{})

--- a/trace.go
+++ b/trace.go
@@ -59,31 +59,44 @@ func Unwrap(err error) error {
 	return err
 }
 
+// UserMessage returns user-friendly part of the error
+func UserMessage(err error) string {
+	if wrap, ok := err.(Error); ok {
+		return wrap.UserMessage()
+	}
+	return err.Error()
+}
+
+// DebugReport returns debug report with all known information
+// about the error including stack trace if it was captured
+func DebugReport(err error) string {
+	if wrap, ok := err.(Error); ok {
+		return wrap.DebugReport()
+	}
+	return err.Error()
+}
+
 func wrap(err error, depth int, args ...interface{}) Error {
 	if err == nil {
 		return nil
 	}
-
-	t := newTrace(runtime.Caller(depth))
-	if s, ok := err.(TraceSetter); ok {
-		s.SetTraces(t.Traces...)
-		return s
+	var wrapper Error
+	if wrap, ok := err.(Error); ok {
+		wrapper = wrap
+	} else {
+		wrapper = newTrace(depth, err)
 	}
-	t.Err = err
-	t.Message = err.Error()
 	if len(args) != 0 {
-		t.DebugMessage = fmt.Sprintf(fmt.Sprintf("%v", args[0]), args[1:]...)
+		wrapper.AddUserMessage(args[0], args[1:]...)
 	}
-	return t
+	return wrapper
 }
 
 // Errorf is similar to fmt.Errorf except that it captures
 // more information about the origin of error, such as
 // callee, line number and function that simplifies debugging
 func Errorf(format string, args ...interface{}) error {
-	t := newTrace(runtime.Caller(1))
-	t.Err = fmt.Errorf(format, args...)
-	return t
+	return newTrace(1, fmt.Errorf(format, args...))
 }
 
 // Fatalf - If debug is false Fatalf calls Errorf. If debug is
@@ -96,28 +109,23 @@ func Fatalf(format string, args ...interface{}) error {
 	}
 }
 
-func newTrace(pc uintptr, filePath string, line int, ok bool) *TraceErr {
-	if !ok {
-		return &TraceErr{
-			nil,
-			Traces{
-				{
-					Path: "unknown_path",
-					Func: "unknown_func",
-					Line: 0,
-				}},
-			"",
-			"",
+func newTrace(depth int, err error) *TraceErr {
+	var pc [32]uintptr
+	count := runtime.Callers(depth+1, pc[:])
+
+	traces := make(Traces, count)
+	for i := 0; i < count; i++ {
+		fn := runtime.FuncForPC(pc[i])
+		filePath, line := fn.FileLine(pc[i])
+		traces[i] = Trace{
+			Func: fn.Name(),
+			Path: filePath,
+			Line: line,
 		}
 	}
 	return &TraceErr{
-		nil,
-		Traces{{
-			Path: filePath,
-			Func: runtime.FuncForPC(pc).Name(),
-			Line: line,
-		}},
-		"",
+		err,
+		traces,
 		"",
 	}
 }
@@ -138,7 +146,7 @@ func (s *Traces) Func() string {
 	return (*s)[0].Func
 }
 
-// String returns debug-friendly representaton of traces
+// String returns debug-friendly representaton of trace stack
 func (s Traces) String() string {
 	if len(s) == 0 {
 		return ""
@@ -147,7 +155,7 @@ func (s Traces) String() string {
 	for i, t := range s {
 		out[i] = t.String()
 	}
-	return strings.Join(out, ",")
+	return strings.Join(out, "\n")
 }
 
 // Trace stores structured trace entry, including file line and path
@@ -173,10 +181,9 @@ func (t *Trace) String() string {
 // TraceErr contains error message and some additional
 // information about the error origin
 type TraceErr struct {
-	Err          error `json:"error"`
-	Traces       `json:"traces"`
-	Message      string `json:"message,omitemtpy"`
-	DebugMessage string `json:"debug_message"`
+	Err     error `json:"error"`
+	Traces  `json:"traces"`
+	Message string `json:"message,omitemtpy"`
 }
 
 type rawTrace struct {
@@ -185,11 +192,35 @@ type rawTrace struct {
 	Message string `json:"message"`
 }
 
-func (e *TraceErr) Error() string {
-	if IsDebug() {
-		return fmt.Sprintf("[%v] %v %v", e.Traces.String(), e.DebugMessage, e.Err.Error())
+// AddUserMessage adds user-friendly message describing the error nature
+func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) {
+	newMessage := fmt.Sprintf(fmt.Sprintf("%v", formatArg), rest...)
+	if len(e.Message) == 0 {
+		e.Message = newMessage
+	} else {
+		e.Message = strings.Join([]string{e.Message, newMessage}, ", ")
+	}
+}
+
+// UserMessage returns user-friendly error message
+func (e *TraceErr) UserMessage() string {
+	if e.Message != "" {
+		return e.Message
 	}
 	return e.Err.Error()
+}
+
+// DebugReport returns develeoper-friendly error report
+func (e *TraceErr) DebugReport() string {
+	return fmt.Sprintf("ERROR REPORT:\nOriginal Error:%v\nStack Trace:\n%v\n%v", e.Err.Error(), e.Traces.String(), e.Message)
+}
+
+// Error returns user-friendly error message when not in debug mode
+func (e *TraceErr) Error() string {
+	if IsDebug() {
+		return e.DebugReport()
+	}
+	return e.UserMessage()
 }
 
 // OrigError returns original wrapped error
@@ -218,13 +249,20 @@ const maxHops = 50
 // So error handlers can use OrigError() to retrieve error from the wrapper
 type Error interface {
 	error
+	// OrigError returns original error wrapped in this error
 	OrigError() error
-}
+	// AddMessage adds formatted user-facing message
+	// to the error, depends on the implementation,
+	// ususally works as fmt.Sprintf(formatArg, rest...)
+	// but implementations can choose another way, e.g. treat
+	// arguments as structured args
+	AddUserMessage(formatArg interface{}, rest ...interface{})
 
-// TraceSetter indicates that this error can store traces
-type TraceSetter interface {
-	Error
-	SetTraces(...Trace)
+	// UserMessage returns user-friendly error message
+	UserMessage() string
+
+	// DebugReport returns develeoper-friendly error report
+	DebugReport() string
 }
 
 // NewAggregate creates a new aggregate instance from the specified

--- a/trace_test.go
+++ b/trace_test.go
@@ -182,8 +182,6 @@ func (s *TraceSuite) TestGenericErrors(c *C) {
 		WriteError(w, err)
 		outerr = ReadError(w.StatusCode, w.Body)
 		c.Assert(testCase.Predicate(outerr), Equals, true, comment)
-		t = outerr.(*TraceErr)
-		c.Assert(len(t.Traces), Not(Equals), 0, comment)
 	}
 }
 
@@ -259,8 +257,6 @@ func (s *TraceSuite) TestAggregateConvertsToCommonErrors(c *C) {
 		WriteError(w, err)
 		outerr = ReadError(w.StatusCode, w.Body)
 		c.Assert(testCase.RoundtripPredicate(outerr), Equals, true, comment)
-		t = outerr.(*TraceErr)
-		c.Assert(len(t.Traces), Not(Equals), 0, comment)
 	}
 }
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -212,6 +212,12 @@ func (s *TraceSuite) TestAggregates(c *C) {
 	c.Assert(err.Error(), DeepEquals, "failed one, failed two")
 }
 
+func (s *TraceSuite) TestErrorf(c *C) {
+	err := Errorf("error")
+	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
+	c.Assert(line(UserMessage(err)), Equals, "error")
+}
+
 func (s *TraceSuite) TestAggregateConvertsToCommonErrors(c *C) {
 	testCases := []struct {
 		Err                error

--- a/trace_test.go
+++ b/trace_test.go
@@ -37,6 +37,11 @@ type TraceSuite struct {
 
 var _ = Suite(&TraceSuite{})
 
+func (s *TraceSuite) TestEmpty(c *C) {
+	c.Assert(DebugReport(nil), Equals, "")
+	c.Assert(UserMessage(nil), Equals, "")
+}
+
 func (s *TraceSuite) TestWrap(c *C) {
 	testErr := &TestError{Param: "param"}
 	err := Wrap(Wrap(testErr))

--- a/udphook.go
+++ b/udphook.go
@@ -3,7 +3,6 @@ package trace
 import (
 	"encoding/json"
 	"net"
-	"runtime"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -67,7 +66,7 @@ type Frame struct {
 // Fire fires the event to the ELK beat
 func (elk *UDPHook) Fire(e *log.Entry) error {
 	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(runtime.Caller(frameNo - 1))
+		t := newTrace(frameNo-1, nil)
 		e.Data[FileField] = t.String()
 		e.Data[FunctionField] = t.Func()
 	}


### PR DESCRIPTION
Provide clear user message and error report separation, capture trace only once

`DebugReport` provides super extensive information about error - stack trace, original error, user message

`UserMessage` provides only user-firendly message either set by `trace.Wrap` or if it's not present resorts back to `err.Error()`

