### PR TITLE
Port orphaned method

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,7 @@ package trace
 import (
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -387,4 +388,9 @@ func IsOAuth2(e error) bool {
 	}
 	_, ok := Unwrap(e).(oe)
 	return ok
+}
+
+// IsEOF returns true if the passed error is io.EOF
+func IsEOF(e error) bool {
+	return Unwrap(e) == io.EOF
 }

--- a/trace_test.go
+++ b/trace_test.go
@@ -19,6 +19,7 @@ package trace
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -54,6 +55,11 @@ func (s *TraceSuite) TestOrigError(c *C) {
 	testErr := fmt.Errorf("some error")
 	err := Wrap(Wrap(testErr))
 	c.Assert(err.OrigError(), Equals, testErr)
+}
+
+func (s *TraceSuite) TestIsEOF(c *C) {
+	c.Assert(IsEOF(io.EOF), Equals, true)
+	c.Assert(IsEOF(Wrap(io.EOF)), Equals, true)
 }
 
 func (s *TraceSuite) TestWrapMessage(c *C) {


### PR DESCRIPTION
Add a method that was accidentally added into trace package vendored inside teleport. The new teleport depends on it.