### PR TITLE
Have trace.Errorf set TraceErr.Message

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -48,13 +48,12 @@ func IsDebug() bool {
 // Wrap takes the original error and wraps it into the Trace struct
 // memorizing the context of the error.
 func Wrap(err error, args ...interface{}) Error {
-	trace := wrapWithDepth(err, 2)
 	if len(args) > 0 {
 		format := args[0]
 		args = args[1:]
-		trace.AddUserMessage(format, args...)
+		return wrap(err, format, args...)
 	}
-	return trace
+	return wrapWithDepth(err, 2)
 }
 
 // Unwrap unwraps error to it's original error
@@ -88,9 +87,11 @@ func DebugReport(err error) string {
 	return err.Error()
 }
 
-func wrap(err error, message string, args ...interface{}) Error {
+func wrap(err error, message interface{}, args ...interface{}) Error {
 	trace := wrapWithDepth(err, 3)
-	trace.AddUserMessage(message, args...)
+	if trace != nil {
+		trace.AddUserMessage(message, args...)
+	}
 	return trace
 }
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -87,7 +87,7 @@ func (s *TraceSuite) TestWrapUserMessage(c *C) {
 }
 
 func (s *TraceSuite) TestWrapNil(c *C) {
-	err1 := Wrap(nil)
+	err1 := Wrap(nil, "message: %v", "extra")
 	c.Assert(err1, IsNil)
 
 	var err2 error

--- a/trace_test.go
+++ b/trace_test.go
@@ -221,7 +221,7 @@ func (s *TraceSuite) TestAggregates(c *C) {
 func (s *TraceSuite) TestErrorf(c *C) {
 	err := Errorf("error")
 	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
-	c.Assert(line(UserMessage(err)), Equals, "error")
+	c.Assert(line(err.(*TraceErr).Message), Equals, "error")
 }
 
 func (s *TraceSuite) TestAggregateConvertsToCommonErrors(c *C) {


### PR DESCRIPTION
to be able to propagate/serialize `Errorf()` errors.

Revisit `wrapWithDepth()` interface to better separate errors with format strings.