### PR TITLE
UDPHook.Fire: make a copy of the log.Entry to ensure safe modification

### DIFF
--- a/udphook.go
+++ b/udphook.go
@@ -65,17 +65,19 @@ type Frame struct {
 
 // Fire fires the event to the ELK beat
 func (elk *UDPHook) Fire(e *log.Entry) error {
+	// Make a copy to safely modify
+	entry := e.WithFields(nil)
 	if frameNo := findFrame(); frameNo != -1 {
 		t := newTrace(frameNo-1, nil)
-		e.Data[FileField] = t.String()
-		e.Data[FunctionField] = t.Func()
+		entry.Data[FileField] = t.String()
+		entry.Data[FunctionField] = t.Func()
 	}
 	data, err := json.Marshal(Frame{
 		Time:    elk.Clock.Now().UTC(),
 		Type:    "trace",
-		Entry:   e.Data,
-		Message: e.Message,
-		Level:   e.Level.String(),
+		Entry:   entry.Data,
+		Message: entry.Message,
+		Level:   entry.Level.String(),
 	})
 	if err != nil {
 		return Wrap(err)

--- a/udphook_test.go
+++ b/udphook_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trace
+
+import (
+	"io/ioutil"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/jonboulle/clockwork"
+	. "gopkg.in/check.v1"
+)
+
+func TestHooks(t *testing.T) { TestingT(t) }
+
+type HooksSuite struct{}
+
+var _ = Suite(&HooksSuite{})
+
+func (s *HooksSuite) TestSafeForConcurrentAccess(c *C) {
+	logger := log.New()
+	logger.Out = ioutil.Discard
+	entry := logger.WithFields(log.Fields{"foo": "bar"})
+	logger.Hooks.Add(&UDPHook{Clock: clockwork.NewFakeClock()})
+	for i := 0; i < 3; i++ {
+		go func(entry *log.Entry) {
+			for i := 0; i < 1000; i++ {
+				entry.Infof("test")
+			}
+		}(entry)
+	}
+}


### PR DESCRIPTION
in case the method runs from multiple goroutines.