### PR TITLE
Sasha/grpc

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,7 +27,7 @@ import (
 
 // NotFound returns new instance of not found error
 func NotFound(message string, args ...interface{}) error {
-	return wrap(&NotFoundError{
+	return WrapWithMessage(&NotFoundError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -70,7 +70,7 @@ func IsNotFound(e error) bool {
 
 // AlreadyExists returns a new instance of AlreadyExists error
 func AlreadyExists(message string, args ...interface{}) error {
-	return wrap(&AlreadyExistsError{
+	return WrapWithMessage(&AlreadyExistsError{
 		fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -111,7 +111,7 @@ func IsAlreadyExists(e error) bool {
 
 // BadParameter returns a new instance of BadParameterError
 func BadParameter(message string, args ...interface{}) error {
-	return wrap(&BadParameterError{
+	return WrapWithMessage(&BadParameterError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -148,7 +148,7 @@ func IsBadParameter(e error) bool {
 
 // CompareFailed returns new instance of CompareFailedError
 func CompareFailed(message string, args ...interface{}) error {
-	return wrap(&CompareFailedError{Message: fmt.Sprintf(message, args...)}, message, args...)
+	return WrapWithMessage(&CompareFailedError{Message: fmt.Sprintf(message, args...)}, message, args...)
 }
 
 // CompareFailedError indicates a failed comparison (e.g. bad password or hash)
@@ -186,7 +186,7 @@ func IsCompareFailed(e error) bool {
 
 // AccessDenied returns new instance of AccessDeniedError
 func AccessDenied(message string, args ...interface{}) error {
-	return wrap(&AccessDeniedError{
+	return WrapWithMessage(&AccessDeniedError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -229,20 +229,20 @@ func ConvertSystemError(err error) error {
 	innerError := Unwrap(err)
 
 	if os.IsNotExist(innerError) {
-		return wrap(&NotFoundError{Message: innerError.Error()}, innerError.Error())
+		return WrapWithMessage(&NotFoundError{Message: innerError.Error()}, innerError.Error())
 	}
 	if os.IsPermission(innerError) {
-		return wrap(&AccessDeniedError{Message: innerError.Error()}, innerError.Error())
+		return WrapWithMessage(&AccessDeniedError{Message: innerError.Error()}, innerError.Error())
 	}
 	switch realErr := innerError.(type) {
 	case *net.OpError:
 		message := fmt.Sprintf("failed to connect to server %v", realErr.Addr)
-		return wrap(&ConnectionProblemError{
+		return WrapWithMessage(&ConnectionProblemError{
 			Message: message,
 			Err:     realErr}, message)
 	case *os.PathError:
 		message := fmt.Sprintf("failed to execute command %v error:  %v", realErr.Path, realErr.Err)
-		return wrap(&AccessDeniedError{
+		return WrapWithMessage(&AccessDeniedError{
 			Message: message,
 		}, message)
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
@@ -254,7 +254,7 @@ func ConvertSystemError(err error) error {
 
 // ConnectionProblem returns new instance of ConnectionProblemError
 func ConnectionProblem(err error, message string, args ...interface{}) error {
-	return wrap(&ConnectionProblemError{
+	return WrapWithMessage(&ConnectionProblemError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
 	}, message, args...)
@@ -292,7 +292,7 @@ func IsConnectionProblem(e error) bool {
 
 // LimitExceeded returns whether new instance of LimitExceededError
 func LimitExceeded(message string, args ...interface{}) error {
-	return wrap(&LimitExceededError{
+	return WrapWithMessage(&LimitExceededError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -359,7 +359,7 @@ func IsTrustError(e error) bool {
 
 // OAuth2 returns new instance of OAuth2Error
 func OAuth2(code, message string, query url.Values) Error {
-	return wrap(&OAuth2Error{
+	return WrapWithMessage(&OAuth2Error{
 		Code:    code,
 		Message: message,
 		Query:   query,

--- a/httplib.go
+++ b/httplib.go
@@ -121,7 +121,7 @@ func unmarshalError(err error, responseBody []byte) error {
 	if len(responseBody) == 0 {
 		return err
 	}
-	var raw rawTrace
+	var raw RawTrace
 	if err2 := json.Unmarshal(responseBody, &raw); err2 != nil {
 		return err
 	}

--- a/trace.go
+++ b/trace.go
@@ -51,7 +51,7 @@ func Wrap(err error, args ...interface{}) Error {
 	if len(args) > 0 {
 		format := args[0]
 		args = args[1:]
-		return wrap(err, format, args...)
+		return WrapWithMessage(err, format, args...)
 	}
 	return wrapWithDepth(err, 2)
 }
@@ -87,7 +87,8 @@ func DebugReport(err error) string {
 	return err.Error()
 }
 
-func wrap(err error, message interface{}, args ...interface{}) Error {
+// WrapWithMessage wraps the original error into Error and adds user message if any
+func WrapWithMessage(err error, message interface{}, args ...interface{}) Error {
 	trace := wrapWithDepth(err, 3)
 	if trace != nil {
 		trace.AddUserMessage(message, args...)
@@ -227,7 +228,7 @@ type TraceErr struct {
 	Message string `json:"message,omitemtpy"`
 }
 
-type rawTrace struct {
+type RawTrace struct {
 	Err     json.RawMessage `json:"error"`
 	Traces  `json:"traces"`
 	Message string `json:"message"`

--- a/trail/trail.go
+++ b/trail/trail.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2016 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@ limitations under the License.
 // Example server that sends the GRPC error and attaches metadata:
 //
 //
-// func (s *server) Echo(ctx context.Context, message *gw.StringMessage) (*gw.StringMessage, error) {
-//    trace.SetDebug(true) // to tell trace to start attaching metadata
-//    // Send sends metadata via grpc header and converts error to GRPC compatible one
-//    return nil, trail.Send(ctx, trace.AccessDenied("missing authorization"))
-// }
+//  func (s *server) Echo(ctx context.Context, message *gw.StringMessage) (*gw.StringMessage, error) {
+//     trace.SetDebug(true) // to tell trace to start attaching metadata
+//     // Send sends metadata via grpc header and converts error to GRPC compatible one
+//     return nil, trail.Send(ctx, trace.AccessDenied("missing authorization"))
+//  }
 //
 // Example client reading error and trace debug infor
 //
-//	var header metadata.MD
+//  var header metadata.MD
 //	r, err := c.Echo(context.Background(), &gw.StringMessage{Value: message}, grpc.Header(&header))
 //	if err != nil {
 //      // FromGRPC reads error, converts it back to trace error and attaches debug metadata

--- a/trail/trail.go
+++ b/trail/trail.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package trail integrates trace errors with GRPC
+package trail
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+
+	"github.com/gravitational/trace"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+// Send is a high level function that:
+// * logs error
+// * converts error to GRPC error
+// * attaches debug metadata to existing metadata if possible
+// * sends the header to GRPC
+func Send(ctx context.Context, err error) error {
+	meta, ok := metadata.FromContext(ctx)
+	if !ok {
+		meta = metadata.New(nil)
+	}
+	if trace.IsDebug() {
+		SetDebugInfo(err, meta)
+	}
+	log.Error(trace.DebugReport(err))
+	if len(meta) != 0 {
+		log.Infof("meta: %v", meta)
+		err2 := grpc.SendHeader(ctx, meta)
+		if err2 != nil {
+			log.Errorf("failed to send metadata: %v", err2)
+		}
+	}
+	return ToGRPC(err)
+}
+
+// DebugReportMetadata is a debug report metadata for the error
+const DebugReportMetadata = "trace-debug-report"
+
+// ToGRPC converts error to GRPC-compatible error
+func ToGRPC(err error) error {
+	userMessage := trace.UserMessage(err)
+	if trace.IsNotFound(err) {
+		return grpc.Errorf(codes.NotFound, userMessage)
+	}
+	if trace.IsAlreadyExists(err) {
+		return grpc.Errorf(codes.AlreadyExists, userMessage)
+	}
+	if trace.IsAccessDenied(err) {
+		return grpc.Errorf(codes.PermissionDenied, userMessage)
+	}
+	if trace.IsCompareFailed(err) {
+		return grpc.Errorf(codes.FailedPrecondition, userMessage)
+	}
+	if trace.IsBadParameter(err) || trace.IsOAuth2(err) {
+		return grpc.Errorf(codes.InvalidArgument, userMessage)
+	}
+	if trace.IsLimitExceeded(err) {
+		return grpc.Errorf(codes.ResourceExhausted, userMessage)
+	}
+	if trace.IsConnectionProblem(err) {
+		return grpc.Errorf(codes.Unavailable, userMessage)
+	}
+	return grpc.Errorf(codes.Unknown, userMessage)
+}
+
+// FromGRPC converts error from GRPC error back to trace.Error
+// Optional debug information can be recovered using metadata
+func FromGRPC(err error, args ...interface{}) error {
+	code := grpc.Code(err)
+	message := grpc.ErrorDesc(err)
+	var e error
+	switch code {
+	case codes.OK:
+		return nil
+	case codes.NotFound:
+		e = &trace.NotFoundError{Message: message}
+	case codes.AlreadyExists:
+		e = &trace.AlreadyExistsError{Message: message}
+	case codes.PermissionDenied:
+		e = &trace.AccessDeniedError{Message: message}
+	case codes.FailedPrecondition:
+		e = &trace.CompareFailedError{Message: message}
+	case codes.InvalidArgument:
+		e = &trace.BadParameterError{Message: message}
+	case codes.ResourceExhausted:
+		e = &trace.LimitExceededError{Message: message}
+	case codes.Unavailable:
+		e = &trace.ConnectionProblemError{Message: message}
+	default:
+		e = errors.New(message)
+	}
+	if len(args) != 0 {
+		if meta, ok := args[0].(metadata.MD); ok {
+			e = DecodeDebugInfo(e, meta)
+		}
+	}
+	return e
+}
+
+// SetDebugInfo adds debug metadata about error to request
+func SetDebugInfo(err error, meta metadata.MD) {
+	if _, ok := err.(*trace.TraceErr); !ok {
+		return
+	}
+	out, err := json.Marshal(err)
+	if err != nil {
+		return
+	}
+	meta[DebugReportMetadata] = []string{
+		base64.StdEncoding.EncodeToString(out),
+	}
+}
+
+// DecodeDebugInfo decodes debug information about error
+// from the metadata and returns error with enriched metadata about it
+func DecodeDebugInfo(err error, meta metadata.MD) error {
+	if meta == nil {
+		return err
+	}
+	encoded, ok := meta[DebugReportMetadata]
+	if !ok || len(encoded) != 1 {
+		return err
+	}
+	data, err2 := base64.StdEncoding.DecodeString(encoded[0])
+	if err2 != nil {
+		return err
+	}
+	var raw trace.RawTrace
+	if err2 := json.Unmarshal(data, &raw); err2 != nil {
+		return err
+	}
+	if len(raw.Traces) != 0 && len(raw.Err) != 0 {
+		return &trace.TraceErr{Traces: raw.Traces, Err: err, Message: raw.Message}
+	}
+	return err
+}

--- a/trail/trail_test.go
+++ b/trail/trail_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	. "gopkg.in/check.v1"
+)
+
+func TestTrail(t *testing.T) { TestingT(t) }
+
+type TrailSuite struct {
+}
+
+var _ = Suite(&TrailSuite{})
+
+// TestConversion makes sure we convert all trace supported errors
+// to and back from GRPC codes
+func (s *TrailSuite) TestConversion(c *C) {
+	type TestCase struct {
+		Error     error
+		Message   string
+		Predicate func(error) bool
+	}
+	testCases := []TestCase{
+		{
+			Error:     trace.AccessDenied("access denied"),
+			Predicate: trace.IsAccessDenied,
+		},
+		{
+			Error:     trace.ConnectionProblem(nil, "problem"),
+			Predicate: trace.IsConnectionProblem,
+		},
+		{
+			Error:     trace.NotFound("not found"),
+			Predicate: trace.IsNotFound,
+		},
+		{
+			Error:     trace.BadParameter("bad parameter"),
+			Predicate: trace.IsBadParameter,
+		},
+		{
+			Error:     trace.CompareFailed("compare failed"),
+			Predicate: trace.IsCompareFailed,
+		},
+		{
+			Error:     trace.AccessDenied("denied"),
+			Predicate: trace.IsAccessDenied,
+		},
+		{
+			Error:     trace.LimitExceeded("exceeded"),
+			Predicate: trace.IsLimitExceeded,
+		},
+	}
+	for i, tc := range testCases {
+		comment := Commentf("test case #v", i+1)
+		grpcError := ToGRPC(tc.Error)
+		c.Assert(grpc.ErrorDesc(grpcError), Equals, tc.Error.Error(), comment)
+		out := FromGRPC(grpcError)
+		c.Assert(tc.Predicate(out), Equals, true, comment)
+	}
+}
+
+// TestNil makes sure conversions of nil to and from GRPC are no-op
+func (s *TrailSuite) TestNil(c *C) {
+	out := FromGRPC(ToGRPC(nil))
+	c.Assert(out, IsNil)
+}
+
+// TestTraces makes sure we pass traces via metadata and can decode it back
+func (s *TrailSuite) TestTraces(c *C) {
+	err := trace.BadParameter("param")
+	meta := metadata.New(nil)
+	SetDebugInfo(err, meta)
+	err2 := FromGRPC(ToGRPC(err), meta)
+	c.Assert(line(trace.DebugReport(err)), Matches, ".*trail_test.go.*")
+	c.Assert(line(trace.DebugReport(err2)), Matches, ".*trail_test.go.*")
+}
+
+func line(s string) string {
+	return strings.Replace(s, "\n", "", -1)
+}


### PR DESCRIPTION
This PR adds GRPC errors support for trace package

```go
// Package trail integrates trace errors with GRPC
//
// Example server that sends the GRPC error and attaches metadata:
//
//
func (s *server) Echo(ctx context.Context, message *gw.StringMessage) (*gw.StringMessage, error) {
   trace.SetDebug(true) // to tell trace to start attaching metadata
   // Send sends metadata via grpc header and converts error to GRPC compatible one
    return nil, trail.Send(ctx, trace.AccessDenied("missing authorization"))
 }

//
// Example client reading error and trace debug infor
//
var header metadata.MD
r, err := c.Echo(context.Background(), &gw.StringMessage{Value: message}, grpc.Header(&header))
if err != nil {
// FromGRPC reads error, converts it back to trace error and attaches debug metadata
// like stack trace of the error origin back to the error
    err = trail.FromGRPC(err, header)
    // this line will log original trace of the error
    log.Errorf("error saying echo: %v", trace.DebugReport(err))
    return
}
```