### PR TITLE
Update to how trace.http handles error messages

### DIFF
--- a/httplib.go
+++ b/httplib.go
@@ -65,19 +65,19 @@ func ReadError(statusCode int, re []byte) error {
 	var e error
 	switch statusCode {
 	case http.StatusNotFound:
-		e = &NotFoundError{}
+		e = &NotFoundError{Message: string(re)}
 	case http.StatusBadRequest:
-		e = &BadParameterError{}
+		e = &BadParameterError{Message: string(re)}
 	case http.StatusPreconditionFailed:
-		e = &CompareFailedError{}
+		e = &CompareFailedError{Message: string(re)}
 	case http.StatusForbidden:
-		e = &AccessDeniedError{}
+		e = &AccessDeniedError{Message: string(re)}
 	case http.StatusConflict:
-		e = &AlreadyExistsError{}
+		e = &AlreadyExistsError{Message: string(re)}
 	case statusTooManyRequests:
-		e = &LimitExceededError{}
+		e = &LimitExceededError{Message: string(re)}
 	case http.StatusGatewayTimeout:
-		e = &ConnectionProblemError{}
+		e = &ConnectionProblemError{Message: string(re)}
 	default:
 		if statusCode < 200 || statusCode > 299 {
 			return Errorf(string(re))


### PR DESCRIPTION
Prior to this comit trace.ReadError(http_error) would "eat" errors returned by the server, replacing them with generic stubs like "object not found".

This prevents HTTP servers from returning _meaningful_ user-facing errors and user is left wondering how to deal with "object not found". This also prevents HTTP servers from returning JSON-formatted errors to API clients. Basically without this fix HTTP error messages are ignored.
