### PR TITLE
JSONFormatter time fix

### DIFF
--- a/log.go
+++ b/log.go
@@ -70,6 +70,7 @@ func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 			FileField:     t.Loc(),
 			FunctionField: t.FuncName(),
 		})
+		new.Time = e.Time
 		new.Level = e.Level
 		new.Message = e.Message
 		e = new


### PR DESCRIPTION
JSONFormatter was always showing "time":"0001-01-01T00:00:00Z"
