### PR TITLE
Update Error to avoid using debug flag for changing its behavior

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -338,8 +338,8 @@ func IsLimitExceeded(e error) bool {
 // TrustError indicates trust-related validation error (e.g. untrusted cert)
 type TrustError struct {
 	// Err is original error
-	Err     error `json:"error"`
-	Message string
+	Err     error  `json:"-"`
+	Message string `json:"message"`
 }
 
 // Error returns log-friendly error description

--- a/httplib.go
+++ b/httplib.go
@@ -22,31 +22,31 @@ func WriteError(w http.ResponseWriter, err error) {
 			err = errors[0]
 		}
 	}
-	writeError(w, err)
+	replyJSON(w, ErrorToCode(err), err)
 }
 
 // ErrorToCode returns an appropriate HTTP status code based on the provided error type
 func ErrorToCode(err error) int {
-	if IsNotFound(err) {
-		return http.StatusNotFound
-	} else if IsBadParameter(err) || IsOAuth2(err) {
-		return http.StatusBadRequest
-	} else if IsCompareFailed(err) {
-		return http.StatusPreconditionFailed
-	} else if IsAccessDenied(err) {
-		return http.StatusForbidden
-	} else if IsAlreadyExists(err) {
-		return http.StatusConflict
-	} else if IsLimitExceeded(err) {
-		return http.StatusTooManyRequests
-	} else if IsConnectionProblem(err) {
+	switch {
+	case IsAggregate(err):
 		return http.StatusGatewayTimeout
+	case IsNotFound(err):
+		return http.StatusNotFound
+	case IsBadParameter(err) || IsOAuth2(err):
+		return http.StatusBadRequest
+	case IsCompareFailed(err):
+		return http.StatusPreconditionFailed
+	case IsAccessDenied(err):
+		return http.StatusForbidden
+	case IsAlreadyExists(err):
+		return http.StatusConflict
+	case IsLimitExceeded(err):
+		return http.StatusTooManyRequests
+	case IsConnectionProblem(err):
+		return http.StatusGatewayTimeout
+	default:
+		return http.StatusInternalServerError
 	}
-	return http.StatusInternalServerError
-}
-
-func writeError(w http.ResponseWriter, err error) {
-	replyJSON(w, ErrorToCode(err), err)
 }
 
 // ReadError converts http error to internal error type

--- a/trace.go
+++ b/trace.go
@@ -249,7 +249,7 @@ func (e *TraceErr) UserMessage() string {
 	if e.Message != "" {
 		return e.Message
 	}
-	return e.Err.Error()
+	return UserMessage(e.Err)
 }
 
 // DebugReport returns develeoper-friendly error report
@@ -259,9 +259,6 @@ func (e *TraceErr) DebugReport() string {
 
 // Error returns user-friendly error message when not in debug mode
 func (e *TraceErr) Error() string {
-	if IsDebug() {
-		return e.DebugReport()
-	}
 	return e.UserMessage()
 }
 

--- a/trail/trail.go
+++ b/trail/trail.go
@@ -56,7 +56,7 @@ import (
 // * attaches debug metadata to existing metadata if possible
 // * sends the header to GRPC
 func Send(ctx context.Context, err error) error {
-	meta, ok := metadata.FromContext(ctx)
+	meta, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		meta = metadata.New(nil)
 	}


### PR DESCRIPTION
This PR removes the implicit change in semantics of `TraceErr.Error` to either dump full stacks or just the message depending on the debug flag - this is superfluous (as the same is achieved via explicit `trace.DebugReport` API) and cumbersome as it prevents from accessing just the message when only the message is required.
