### PR TITLE
Implement GoStringer for better test output formatting

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -280,6 +280,12 @@ func (e *TraceErr) OrigError() error {
 	return err
 }
 
+// GoString formats this trace object for use with
+// with the "%#v" format string
+func (e *TraceErr) GoString() string {
+	return e.DebugReport()
+}
+
 // maxHops is a max supported nested depth for errors
 const maxHops = 50
 


### PR DESCRIPTION
Without this change, all invocations of
```go
c.Assert(err, IsNil)
```
Where `err != nil`, result in something along the lines of:

```shell
/path/to/builder.go:157:
    c.Assert(err, IsNil)
... value *trace.TraceErr = &trace.TraceErr{Err:(*trace.NotFoundError)(0xc4204bad80), Traces:trace.Traces{trace.Trace{Path:"/path/to/lib/app/service/merge.go", Func:"github.com/repo/lib/app/service.mergeRuntime", Line:48}, trace.Trace{Path:"/path/to/lib/app/service/merge.go", Func:"github.com/repo/lib/app/service.mergeManifests", Line:17}, trace.Trace{Path:"/path/to/lib/app/service/app.go", Func:"github.com/repo/lib/app/service.(*applications).resolveManifest", Line:749}, trace.Trace{Path:"/path/to/lib/app/service/app.go", Func:"github.com/repo/lib/app/service.(*applications).createApp", Line:538}, trace.Trace{Path:"/path/to/lib/app/service/app.go", Func:"github.com/repo/lib/app/service.(*applications).CreateAppWithManifest", Line:507}, trace.Trace{Path:"/path/to/lib/app/service/app.go", Func:"github.com/repo/lib/app/service.(*applications).CreateApp", Line:534}, trace.Trace{Path:"/path/to/lib/app/suite/builder.go", Func:"github.com/repo/lib/app/suite.CreateApplicationFromData", Line:156}, trace.Trace{Path:"/path/to/lib/app/suite/builder.go", Func:"github.com/repo/lib/app/suite.createApp", Line:145}, trace.Trace{Path:"/path/to/lib/app/suite/builder.go", Func:"github.com/repo/lib/app/suite.CreateAppWithDeps", Line:57}, trace.Trace{Path:"/path/to/lib/ops/suite/opssuite.go", Func:"github.com/repo/lib/ops/suite.SetUpTestPackage", Line:45}, trace.Trace{Path:"/path/to/lib/install/plan_test.go", Func:"github.com/repo/lib/install.(*PlanSuite).SetUpSuite", Line:63}, trace.Trace{Path:"/path/to/go/go/go/src/runtime/asm_amd64.s", Func:"runtime.call32", Line:573}, trace.Trace{Path:"/path/to/go/go/go/src/reflect/value.go", Func:"reflect.Value.call", Line:450}, trace.Trace{Path:"/path/to/go/go/go/src/reflect/value.go", Func:"reflect.Value.Call", Line:308}, trace.Trace{Path:"/path/to/vendor/gopkg.in/check.v1/check.go", Func:"github.com/repo/vendor/gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1", Line:718}, trace.Trace{Path:"/path/to/vendor/gopkg.in/check.v1/check.go", Func:"github.com/repo/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1", Line:663}, trace.Trace{Path:"/path/to/go/go/go/src/runtime/asm_amd64.s", Func:"runtime.goexit", Line:2362}}, Message:"no runtime package specified in manifest"} ("no runtime package specified in manifest")
```

With the change, the output looks like this:
```shell
/path/to/lib/app/suite/builder.go:157:
    c.Assert(err, IsNil)
... value *trace.TraceErr =
ERROR REPORT:
Original Error: *trace.NotFoundError no runtime package specified in manifest
Stack Trace:
	/path/to/lib/app/service/merge.go:48 github.com/repo/lib/app/service.mergeRuntime
	/path/to/lib/app/service/merge.go:17 github.com/repo/lib/app/service.mergeManifests
	/path/to/lib/app/service/app.go:749 github.com/repo/lib/app/service.(*applications).resolveManifest
	/path/to/lib/app/service/app.go:538 github.com/repo/lib/app/service.(*applications).createApp
	/path/to/lib/app/service/app.go:507 github.com/repo/lib/app/service.(*applications).CreateAppWithManifest
	/path/to/lib/app/service/app.go:534 github.com/repo/lib/app/service.(*applications).CreateApp
	/path/to/lib/app/suite/builder.go:156 github.com/repo/lib/app/suite.CreateApplicationFromData
	/path/to/lib/app/suite/builder.go:145 github.com/repo/lib/app/suite.createApp
	/path/to/lib/app/suite/builder.go:57 github.com/repo/lib/app/suite.CreateAppWithDeps
	/path/to/lib/ops/suite/opssuite.go:45 github.com/repo/lib/ops/suite.SetUpTestPackage
	/path/to/lib/install/plan_test.go:63 github.com/repo/lib/install.(*PlanSuite).SetUpSuite
	/path/to/go/go/go/src/runtime/asm_amd64.s:573 runtime.call32
	/path/to/go/go/go/src/reflect/value.go:450 reflect.Value.call
	/path/to/go/go/go/src/reflect/value.go:308 reflect.Value.Call
	/path/to/vendor/gopkg.in/check.v1/check.go:718 github.com/repo/vendor/gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1
	/path/to/vendor/gopkg.in/check.v1/check.go:663 github.com/repo/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1
	/path/to/go/go/go/src/runtime/asm_amd64.s:2362 runtime.goexit
User Message: no runtime package specified in manifest
("no runtime package specified in manifest")
```