### PR TITLE
add fields

### DIFF
--- a/trace_test.go
+++ b/trace_test.go
@@ -42,7 +42,7 @@ func (s *TraceSuite) TestEmpty(c *C) {
 	c.Assert(DebugReport(nil), Equals, "")
 	c.Assert(UserMessage(nil), Equals, "")
 	c.Assert(UserMessageWithFields(nil), Equals, "")
-	c.Assert(GetFields(nil), IsNil)
+	c.Assert(GetFields(nil), DeepEquals, map[string]interface{}{})
 }
 
 func (s *TraceSuite) TestWrap(c *C) {
@@ -88,7 +88,7 @@ func (s *TraceSuite) TestUserMessageWithFields(c *C) {
 
 func (s *TraceSuite) TestGetFields(c *C) {
 	testErr := fmt.Errorf("description")
-	c.Assert(GetFields(testErr), IsNil)
+	c.Assert(GetFields(testErr), DeepEquals, map[string]interface{}{})
 
 	fields := map[string]interface{}{
 		"test_key": "test_value",

--- a/trace_test.go
+++ b/trace_test.go
@@ -41,6 +41,8 @@ var _ = Suite(&TraceSuite{})
 func (s *TraceSuite) TestEmpty(c *C) {
 	c.Assert(DebugReport(nil), Equals, "")
 	c.Assert(UserMessage(nil), Equals, "")
+	c.Assert(UserMessageWithFields(nil), Equals, "")
+	c.Assert(GetFields(nil), IsNil)
 }
 
 func (s *TraceSuite) TestWrap(c *C) {
@@ -71,6 +73,28 @@ func (s *TraceSuite) TestWrapUserMessage(c *C) {
 
 	err = Wrap(err, "user message 2")
 	c.Assert(line(UserMessage(err)), Equals, "user message, user message 2")
+}
+
+func (s *TraceSuite) TestUserMessageWithFields(c *C) {
+	testErr := fmt.Errorf("description")
+	c.Assert(UserMessageWithFields(testErr), Equals, testErr.Error())
+
+	err := Wrap(testErr, "user message")
+	c.Assert(line(UserMessageWithFields(err)), Equals, "user message")
+
+	err.AddField("test_key", "test_value")
+	c.Assert(line(UserMessageWithFields(err)), Equals, "test_key=\"test_value\" user message")
+}
+
+func (s *TraceSuite) TestGetFields(c *C) {
+	testErr := fmt.Errorf("description")
+	c.Assert(GetFields(testErr), IsNil)
+
+	fields := map[string]interface{}{
+		"test_key": "test_value",
+	}
+	err := Wrap(testErr).AddFields(fields)
+	c.Assert(GetFields(err), DeepEquals, fields)
 }
 
 func (s *TraceSuite) TestWrapNil(c *C) {

--- a/trace_test.go
+++ b/trace_test.go
@@ -408,7 +408,23 @@ func (s *TraceSuite) TestAggregates(c *C) {
 func (s *TraceSuite) TestErrorf(c *C) {
 	err := Errorf("error")
 	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
+	c.Assert(line(DebugReport(err)), Not(Matches), "*.Fields.*")
 	c.Assert(line(err.(*TraceErr).Message), Equals, "error")
+}
+
+func (s *TraceSuite) TestWithField(c *C) {
+	err := Wrap(Errorf("error")).AddField("testfield", true)
+	c.Assert(line(DebugReport(err)), Matches, "*.testfield.*")
+}
+
+func (s *TraceSuite) TestWithFields(c *C) {
+	err := Wrap(Errorf("error")).AddFields(map[string]interface{}{
+		"testfield1": true,
+		"testfield2": "value2",
+	})
+	c.Assert(line(DebugReport(err)), Matches, "*.Fields.*")
+	c.Assert(line(DebugReport(err)), Matches, "*.testfield1: true.*")
+	c.Assert(line(DebugReport(err)), Matches, "*.testfield2: value2.*")
 }
 
 func (s *TraceSuite) TestAggregateConvertsToCommonErrors(c *C) {


### PR DESCRIPTION
This is something we discussed quite awhile ago in #41, this PR attempts to add the ability to add variables / fields to an error in the trace package. I approached it sort of logrus style, but trying to remain consistent with the naming convention / style already in place.

So trace.Wrap(err).AddField(key, value) will allow a kvp to the error, that can be recalled later (GetFields()), be part of a debug report, or as a user message with fields. I didn't want to redefine the existing UserMessage, because presumably it get's surfaced to the user in ways that we don't want the KVP to show up.

Let me know what you think.