### PR TITLE
Enable custom caller formatting in TextFormatter.

### DIFF
--- a/log.go
+++ b/log.go
@@ -74,6 +74,9 @@ type TextFormatter struct {
 	ComponentPadding int
 	// EnableColors enables colored output
 	EnableColors bool
+	// FormatCaller is a function to return (part) of source file path for output.
+	// Defaults to filePathAndLine() if unspecified
+	FormatCaller func() (caller string)
 }
 
 // Format implements logrus.Formatter interface and adds file and line
@@ -85,12 +88,12 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 		}
 	}()
 
-	var file string
-	if cursor := findFrame(); cursor != nil {
-		t := newTraceFromFrames(*cursor, nil)
-		file = t.Loc()
+	formatCaller := tf.FormatCaller
+	if formatCaller == nil {
+		formatCaller = filePathAndLine
 	}
 
+	caller := formatCaller()
 	w := &writer{}
 
 	// time
@@ -143,9 +146,9 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 		w.writeMap(e.Data)
 	}
 
-	// file, if present, always last
-	if file != "" {
-		w.writeField(file, noColor)
+	// caller, if present, always last
+	if caller != "" {
+		w.writeField(caller, noColor)
 	}
 
 	w.WriteByte('\n')
@@ -173,6 +176,16 @@ func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 		e = new
 	}
 	return j.JSONFormatter.Format(e)
+}
+
+// filePathAndLine formats the caller in the form path/segment:<line number>
+// for output in the log
+func filePathAndLine() (path string) {
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
+		return t.Loc()
+	}
+	return ""
 }
 
 var frameIgnorePattern = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)

--- a/log.go
+++ b/log.go
@@ -90,7 +90,7 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 
 	formatCaller := tf.FormatCaller
 	if formatCaller == nil {
-		formatCaller = filePathAndLine
+		formatCaller = formatCallerWithPathAndLine
 	}
 
 	caller := formatCaller()
@@ -178,9 +178,9 @@ func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 	return j.JSONFormatter.Format(e)
 }
 
-// filePathAndLine formats the caller in the form path/segment:<line number>
+// formatCallerWithPathAndLine formats the caller in the form path/segment:<line number>
 // for output in the log
-func filePathAndLine() (path string) {
+func formatCallerWithPathAndLine() (path string) {
 	if cursor := findFrame(); cursor != nil {
 		t := newTraceFromFrames(*cursor, nil)
 		return t.Loc()


### PR DESCRIPTION
This change will allow to customize caller output in text-based logs from this:
```
2019-06-07T14:11:55Z INFO             Executing phase: /elect. advertise-ip:172.28.128.14 hostname:node-2 phase:/elect install/hook.go:56
2019-06-07T14:11:59Z DEBU [FSM:JOIN]  Applied StateChange(Phase=/elect, State=completed). install/hook.go:56
```
to this:
```
2019-06-07T14:11:55Z INFO             Executing phase: /elect. advertise-ip:172.28.128.14 hostname:node-2 phase:/elect fsm/logger.go:55
2019-06-07T14:11:59Z DEBU [FSM:JOIN]  Applied StateChange(Phase=/elect, State=completed). expand/fsm.go:173
```
If you don't see the difference, pay attention to the caller field which comes last for each logging entry.