### PR TITLE
Don't treat HTTP 3xx codes as errors

### DIFF
--- a/httplib.go
+++ b/httplib.go
@@ -74,7 +74,7 @@ func ReadError(statusCode int, re []byte) error {
 	case http.StatusGatewayTimeout:
 		e = &ConnectionProblemError{Message: string(re)}
 	default:
-		if statusCode < 200 || statusCode > 299 {
+		if statusCode < 200 || statusCode >= 400 {
 			return Errorf(string(re))
 		}
 		return nil


### PR DESCRIPTION
This change will stop trace from returning an error in httplib if it
encounters an statuscode of in the 300-399 range.

As per RFC7231, The 3xx class of status code indicates that further action
needs to be taken by the user agent in order to fulfill the request. It does
not signal an error.

I encountered this problem while working with the Salesforce API, which
might occasionally return a 300 with a response body if the user has to
choose between multiple resources. The application is set up to deal
with this, however trace will interpret this scenario as an error and
return prematurely.

Fyi, I'm also of the opinion that the 1xx class of status code shouldn't
be treated as an error, but I don't have any real-world examples backing
this claim.