### PR TITLE
Proxy error to persist the trace of the error coming over the wire

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -57,7 +57,8 @@ func (e *NotFoundError) OrigError() error {
 
 // IsNotFound returns whether this error is of NotFoundError type
 func IsNotFound(err error) bool {
-	_, ok := Unwrap(err).(interface {
+	err = Unwrap(err)
+	_, ok := err.(interface {
 		IsNotFoundError() bool
 	})
 	if !ok {

--- a/errors.go
+++ b/errors.go
@@ -285,7 +285,7 @@ func ConvertSystemError(err error) error {
 			Message: message,
 		}, message)
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
-		return wrapWithDepth(&TrustError{Err: innerError}, 2)
+		return newTrace(&TrustError{Err: innerError}, 2)
 	}
 	if _, ok := innerError.(net.Error); ok {
 		return WrapWithMessage(&ConnectionProblemError{

--- a/errors.go
+++ b/errors.go
@@ -56,16 +56,14 @@ func (e *NotFoundError) OrigError() error {
 }
 
 // IsNotFound returns whether this error is of NotFoundError type
-func IsNotFound(e error) bool {
-	type nf interface {
+func IsNotFound(err error) bool {
+	_, ok := Unwrap(err).(interface {
 		IsNotFoundError() bool
-	}
-	err := Unwrap(e)
-	_, ok := err.(nf)
+	})
 	if !ok {
 		return os.IsNotExist(err)
 	}
-	return ok
+	return true
 }
 
 // AlreadyExists returns a new instance of AlreadyExists error
@@ -252,11 +250,10 @@ func (e *AccessDeniedError) OrigError() error {
 }
 
 // IsAccessDenied detects if this error is of AccessDeniedError type
-func IsAccessDenied(e error) bool {
-	type ad interface {
+func IsAccessDenied(err error) bool {
+	_, ok := Unwrap(err).(interface {
 		IsAccessDeniedError() bool
-	}
-	_, ok := Unwrap(e).(ad)
+	})
 	return ok
 }
 

--- a/httplib.go
+++ b/httplib.go
@@ -8,19 +8,21 @@ import (
 
 // WriteError sets up HTTP error response and writes it to writer w
 func WriteError(w http.ResponseWriter, err error) {
-	if IsAggregate(err) {
-		for i := 0; i < maxHops; i++ {
-			var aggErr Aggregate
-			var ok bool
-			if aggErr, ok = Unwrap(err).(Aggregate); !ok {
-				break
-			}
-			errors := aggErr.Errors()
-			if len(errors) == 0 {
-				break
-			}
-			err = errors[0]
+	if !IsAggregate(err) {
+		replyJSON(w, ErrorToCode(err), err)
+		return
+	}
+	for i := 0; i < maxHops; i++ {
+		var aggErr Aggregate
+		var ok bool
+		if aggErr, ok = Unwrap(err).(Aggregate); !ok {
+			break
 		}
+		errors := aggErr.Errors()
+		if len(errors) == 0 {
+			break
+		}
+		err = errors[0]
 	}
 	replyJSON(w, ErrorToCode(err), err)
 }

--- a/httplib.go
+++ b/httplib.go
@@ -56,32 +56,32 @@ func ErrorToCode(err error) int {
 // ReadError converts http error to internal error type
 // based on HTTP response code and HTTP body contents
 // if status code does not indicate error, it will return nil
-func ReadError(statusCode int, re []byte) error {
-	var e error
+func ReadError(statusCode int, respBytes []byte) error {
+	var err error
 	switch statusCode {
 	case http.StatusNotFound:
-		e = &NotFoundError{Message: string(re)}
+		err = &NotFoundError{Message: string(respBytes)}
 	case http.StatusBadRequest:
-		e = &BadParameterError{Message: string(re)}
+		err = &BadParameterError{Message: string(respBytes)}
 	case http.StatusNotImplemented:
-		e = &NotImplementedError{Message: string(re)}
+		err = &NotImplementedError{Message: string(respBytes)}
 	case http.StatusPreconditionFailed:
-		e = &CompareFailedError{Message: string(re)}
+		err = &CompareFailedError{Message: string(respBytes)}
 	case http.StatusForbidden:
-		e = &AccessDeniedError{Message: string(re)}
+		err = &AccessDeniedError{Message: string(respBytes)}
 	case http.StatusConflict:
-		e = &AlreadyExistsError{Message: string(re)}
+		err = &AlreadyExistsError{Message: string(respBytes)}
 	case http.StatusTooManyRequests:
-		e = &LimitExceededError{Message: string(re)}
+		err = &LimitExceededError{Message: string(respBytes)}
 	case http.StatusGatewayTimeout:
-		e = &ConnectionProblemError{Message: string(re)}
+		err = &ConnectionProblemError{Message: string(respBytes)}
 	default:
 		if statusCode < 200 || statusCode >= 400 {
-			return Errorf(string(re))
+			return wrapProxy(Errorf(string(respBytes)))
 		}
 		return nil
 	}
-	return unmarshalError(e, re)
+	return wrapProxy(unmarshalError(err, respBytes))
 }
 
 func replyJSON(w http.ResponseWriter, code int, err error) {

--- a/httplib.go
+++ b/httplib.go
@@ -87,28 +87,16 @@ func ReadError(statusCode int, respBytes []byte) error {
 func replyJSON(w http.ResponseWriter, code int, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-
 	var out []byte
-	if IsDebug() {
-		// trace error can marshal itself,
-		// otherwise capture error message and marshal it explicitly
-		var obj interface{} = err
-		if _, ok := err.(*TraceErr); !ok {
-			obj = externalError{Message: err.Error()}
-		}
-		out, err = json.MarshalIndent(obj, "", "    ")
-		if err != nil {
-			out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
-		}
-	} else {
-		innerError := err
-		if terr, ok := err.(Error); ok {
-			innerError = terr.OrigError()
-		}
-		out, err = json.Marshal(externalError{Message: innerError.Error()})
-		if err != nil {
-			out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
-		}
+	// trace error can marshal itself,
+	// otherwise capture error message and marshal it explicitly
+	var obj interface{} = err
+	if _, ok := err.(*TraceErr); !ok {
+		obj = externalError{Message: err.Error()}
+	}
+	out, err = json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
 	}
 	w.Write(out)
 }

--- a/trace.go
+++ b/trace.go
@@ -576,8 +576,8 @@ type errorReport struct {
 	StackTrace string
 	// UserMessage is the user-facing message (if any)
 	UserMessage string
-	// Caught optionally specifies the stack trace where the exception
-	// has been caught (if the exception was transmitted over the wire)
+	// Caught optionally specifies the stack trace where the error
+	// has been recorded after coming over the wire
 	Caught string
 }
 
@@ -589,7 +589,7 @@ Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
 {{range $key, $value := .Fields}}  {{$key}}: {{$value}}
 {{end}}{{end}}Stack Trace:
 {{.StackTrace}}
-{{if .Caught}}caught:
+{{if .Caught}}Caught:
 {{.Caught}}
 User Message: {{.UserMessage}}
 {{else}}User Message: {{.UserMessage}}{{end}}`

--- a/trace.go
+++ b/trace.go
@@ -286,6 +286,17 @@ func (t *Trace) String() string {
 	return fmt.Sprintf("%v:%v", file, t.Line)
 }
 
+// MarshalJSON marshals this error as JSON-encoded payload
+func (r *TraceErr) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	type marshalableError TraceErr
+	err := marshalableError(*r)
+	err.Err = &externalError{Message: r.Err.Error()}
+	return json.Marshal(err)
+}
+
 // TraceErr contains error message and some additional
 // information about the error origin
 type TraceErr struct {
@@ -316,6 +327,8 @@ type RawTrace struct {
 	Message string `json:"message"`
 	// Messages is a list of user messages added to this error.
 	Messages []string `json:"messages"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // AddUserMessage adds user-friendly message describing the error nature

--- a/trace.go
+++ b/trace.go
@@ -300,21 +300,19 @@ type TraceErr struct {
 	// Messages is a list of user messages added to this error.
 	Messages []string `json:"messages,omitempty"`
 	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
-	Fields map[string]interface{} `json:"fields,omitempty`
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // Fields maps arbitrary keys to values inside an error
 type Fields map[string]interface{}
 
-// RawTrace is the trace error that gets passed over the wire.
+// RawTrace describes the error trace on the wire
 type RawTrace struct {
-	// Err is the json-encoded error.
-	Err json.RawMessage `json:"error"`
-	// Traces represents the error callstack.
-	Traces `json:"traces"`
-	// Message is the user message.
-	//
-	// This field is obsolete, replaced by messages list below.
+	// Err specifies the original error
+	Err json.RawMessage `json:"error,omitempty"`
+	// Traces lists the stack traces at the moment the error was recorded
+	Traces `json:"traces,omitempty"`
+	// Message specifies the optional user-facing message
 	Message string `json:"message"`
 	// Messages is a list of user messages added to this error.
 	Messages []string `json:"messages"`

--- a/trace_test.go
+++ b/trace_test.go
@@ -402,19 +402,23 @@ func (s *TraceSuite) TestGenericErrors(c *C) {
 
 // Make sure we write some output produced by standard errors
 func (s *TraceSuite) TestWriteExternalErrors(c *C) {
-	err := fmt.Errorf("snap!")
+	err := Wrap(fmt.Errorf("snap!"))
 
 	SetDebug(true)
 	w := newTestWriter()
 	WriteError(w, err)
+	extErr := ReadError(w.StatusCode, w.Body)
 	c.Assert(w.StatusCode, Equals, http.StatusInternalServerError)
 	c.Assert(strings.Replace(string(w.Body), "\n", "", -1), Matches, "*.snap.*")
+	c.Assert(err.Error(), Equals, extErr.Error())
 
 	SetDebug(false)
 	w = newTestWriter()
 	WriteError(w, err)
+	extErr = ReadError(w.StatusCode, w.Body)
 	c.Assert(w.StatusCode, Equals, http.StatusInternalServerError)
 	c.Assert(strings.Replace(string(w.Body), "\n", "", -1), Matches, "*.snap.*")
+	c.Assert(err.Error(), Equals, extErr.Error())
 }
 
 type netError struct {

--- a/trace_test.go
+++ b/trace_test.go
@@ -26,15 +26,13 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
-
 	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
 )
 
 func TestTrace(t *testing.T) { TestingT(t) }
 
-type TraceSuite struct {
-}
+type TraceSuite struct{}
 
 var _ = Suite(&TraceSuite{})
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -369,7 +369,7 @@ func (s *TraceSuite) TestGenericErrors(c *C) {
 		},
 	}
 
-	for _, testCase := range testCases[:1] {
+	for _, testCase := range testCases {
 		comment := Commentf(testCase.comment)
 		SetDebug(true)
 		err := testCase.Err
@@ -387,12 +387,11 @@ func (s *TraceSuite) TestGenericErrors(c *C) {
 		WriteError(w, err)
 
 		outerr := ReadError(w.StatusCode, w.Body)
-		proxyErr := WrapProxy(outerr)
-
-		c.Assert(testCase.Predicate(outerr), Equals, true, comment)
 		if traceErr, ok = outerr.(*TraceErr); !ok {
 			c.Fatal("Expected outerr to be of type *TraceErr")
 		}
+		proxyErr := WrapProxy(outerr)
+		c.Assert(testCase.Predicate(proxyErr), Equals, true, comment)
 		c.Assert(len(traceErr.Traces), Not(Equals), 0, comment)
 
 		SetDebug(false)

--- a/trace_test.go
+++ b/trace_test.go
@@ -387,8 +387,6 @@ func (s *TraceSuite) TestGenericErrors(c *C) {
 		WriteError(w, err)
 
 		outErr := ReadError(w.StatusCode, w.Body)
-		c.Logf("Before wire: %s.\n", DebugReport(err))
-		c.Logf("After wire: %s.\n", DebugReport(outErr))
 		if _, ok := outErr.(proxyError); !ok {
 			c.Fatal("Expected error to be of type proxyError")
 		}


### PR DESCRIPTION
This PR fixes a couple of annoyances I've encountered:
### Implicit trace of the error arriving over the wire
If a caller receives an error over the wire, the package would implicitly use the error's trace state so that it was not possible to see where the error was actually received. Consider an example:
An error is generated on the server:
```
ERROR REPORT:
Original Error: *errors.errorString external error
Stack Trace:
	/gopath/server/server.go:372 server.(*Server).Service
	/gopath/server/server.go:142 server.(*Server).Serve
	/go/go/src/runtime/asm_amd64.s:1337 runtime.goexit
User Message: external error
```
and the client upon receiving the error, will log the same stack trace:
```
ERROR REPORT:
Original Error: *errors.errorString external error
Stack Trace:
	/gopath/server/server.go:372 server.(*Server).Service
	/gopath/server/server.go:142 server.(*Server).Serve
	/go/go/src/runtime/asm_amd64.s:1337 runtime.goexit
User Message: external error
```

Instead, this updates the logic to preserve both the original server error **and** the point where the errror was received on the client, so instead the client would log:
```
ERROR REPORT:
Original Error: *errors.errorString external error
Stack Trace:
	/gopath/server/server.go:372 server.(*Server).Service
	/gopath/server/server.go:142 server.(*Server).Serve
	/go/go/src/runtime/asm_amd64.s:1337 runtime.goexit
caught:
	/gopath/client/client.go:21 client.(*Client).CallService
	/gopath/main.go:14 main.main
	/go/go/src/runtime/asm_amd64.s:1337 runtime.goexit
User Message: external error
```
Note, that the type checkers (`IsNotFound`, `IsBadParameter`, etc.) still work as before.

### Broken stack traces on the receiver side for external errors that arrive over the wire
Using the same client/server example from above, if the generated error is not one of the types built into trace (i.e. `NotFoundError`, `BadParameterError`, etc.), the client will log the following error trace:
```
ERROR REPORT:
Original Error: *errors.errorString {
    "error": {},
    "traces": [
        {
            "path": "/gopath/server/server.go",
            "func": "server.(*Server).Service",
            "line": 372
        },
        {
            "path": "/gopath/server/server.go",
            "func": "server.(*Server).Serve",
            "line": 142
        },
        {
            "path": "/go/go/src/runtime/asm_amd64.s",
            "func": "runtime.goexit",
            "line": 1337
        }
    ],
    "message": "external error",
    "Fields": null,
}
```