### PR TITLE
Better user message.

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -286,9 +286,11 @@ type TraceErr struct {
 	Err error `json:"error"`
 	// Traces is a slice of stack trace entries for the error
 	Traces `json:"traces"`
-	// Message is an optional message that can be wrapped with the original error
+	// Message is an optional message that can be wrapped with the original error.
+	//
+	// This field is obsolete, replaced by messages list below.
 	Message string `json:"message,omitempty"`
-	// Messages is a list of user messages
+	// Messages is a list of user messages added to this error.
 	Messages []string `json:"messages,omitempty"`
 	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
 	Fields map[string]interface{} `json:"fields,omitempty`
@@ -297,18 +299,24 @@ type TraceErr struct {
 // Fields maps arbitrary keys to values inside an error
 type Fields map[string]interface{}
 
+// RawTrace is the trace error that gets passed over the wire.
 type RawTrace struct {
-	Err      json.RawMessage `json:"error"`
-	Traces   `json:"traces"`
-	Message  string   `json:"message"`
+	// Err is the json-encoded error.
+	Err json.RawMessage `json:"error"`
+	// Traces represents the error callstack.
+	Traces `json:"traces"`
+	// Message is the user message.
+	//
+	// This field is obsolete, replaced by messages list below.
+	Message string `json:"message"`
+	// Messages is a list of user messages added to this error.
 	Messages []string `json:"messages"`
 }
 
 // AddUserMessage adds user-friendly message describing the error nature
 func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr {
 	newMessage := fmt.Sprintf(fmt.Sprintf("%v", formatArg), rest...)
-	// Prepend so messages higher up the call stack go first.
-	e.Messages = append([]string{newMessage}, e.Messages...)
+	e.Messages = append(e.Messages, newMessage)
 	return e
 }
 
@@ -328,22 +336,24 @@ func (e *TraceErr) AddField(k string, v interface{}) *TraceErr {
 	if e.Fields == nil {
 		e.Fields = make(map[string]interface{}, 1)
 	}
-
 	e.Fields[k] = v
-
 	return e
 }
 
 // UserMessage returns user-friendly error message
 func (e *TraceErr) UserMessage() string {
 	if len(e.Messages) > 0 {
-		result := e.Messages[0]
-		for i, msg := range e.Messages[1:] {
-			result = fmt.Sprintf("%v\n%v%v", result, strings.Repeat("\t", i+1), msg)
+		// Format all collected messages in the reverse order, with each error
+		// on its own line with appropriate indentation so they form a tree and
+		// it's easy to see the cause and effect.
+		result := e.Messages[len(e.Messages)-1]
+		for index, indent := len(e.Messages)-1, 1; index > 0; index, indent = index-1, indent+1 {
+			result = fmt.Sprintf("%v\n%v%v", result, strings.Repeat("\t", indent), e.Messages[index-1])
 		}
 		return result
 	}
-	if e.Message != "" { // For backwards compatibility.
+	if e.Message != "" {
+		// For backwards compatibility return the old user message if it's present.
 		return e.Message
 	}
 	return UserMessage(e.Err)

--- a/trace_test.go
+++ b/trace_test.go
@@ -72,7 +72,7 @@ func (s *TraceSuite) TestWrapUserMessage(c *C) {
 	c.Assert(line(UserMessage(err)), Equals, "user message")
 
 	err = Wrap(err, "user message 2")
-	c.Assert(line(UserMessage(err)), Equals, "user message, user message 2")
+	c.Assert(line(UserMessage(err)), Equals, "user message 2\tuser message")
 }
 
 func (s *TraceSuite) TestUserMessageWithFields(c *C) {
@@ -433,7 +433,7 @@ func (s *TraceSuite) TestErrorf(c *C) {
 	err := Errorf("error")
 	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
 	c.Assert(line(DebugReport(err)), Not(Matches), "*.Fields.*")
-	c.Assert(line(err.(*TraceErr).Message), Equals, "error")
+	c.Assert(err.(*TraceErr).Messages, DeepEquals, []string{"error"})
 }
 
 func (s *TraceSuite) TestWithField(c *C) {


### PR DESCRIPTION
Some UX improvements to how trace deals with user message:

* When a new user message is added, add it to the list instead of appending to a string so it's easier to appropriately format them later.
* Allow chaining in AddUserMessage method (by returning TraceErr).
* When printing the error, each collected user message is printed on its own line with an indentation to make it easier to make sense out of the chain of errors. They are also printed in reverse order, from top to bottom. See example below.

Before:

```
[ERROR]: failed to decode prometheus-operator/templates/prometheus/service.yaml: error converting YAML to JSON: yaml: line 4: mapping values are not allowed in this context, failed to parse Helm chart resources "charts/prometheus-operator": failed to decode prometheus-operator/templates/prometheus/service.yaml: error converting YAML to JSON: yaml: line 4: mapping values are not allowed in this context
```

After:

```
[ERROR]: failed to parse Helm chart resources "charts/prometheus-operator"
	failed to decode prometheus-operator/templates/prometheus/service.yaml
		error converting YAML to JSON: yaml: line 4: mapping values are not allowed in this context
```