### PR TITLE
Wrap GRPC errors to include stack trace.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,7 +27,7 @@ import (
 
 // NotFound returns new instance of not found error
 func NotFound(message string, args ...interface{}) Error {
-	return WrapWithMessage(&NotFoundError{
+	return wrapWithMessage(1, &NotFoundError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -69,7 +69,7 @@ func IsNotFound(err error) bool {
 
 // AlreadyExists returns a new instance of AlreadyExists error
 func AlreadyExists(message string, args ...interface{}) Error {
-	return WrapWithMessage(&AlreadyExistsError{
+	return wrapWithMessage(1, &AlreadyExistsError{
 		fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -110,7 +110,7 @@ func IsAlreadyExists(e error) bool {
 
 // BadParameter returns a new instance of BadParameterError
 func BadParameter(message string, args ...interface{}) Error {
-	return WrapWithMessage(&BadParameterError{
+	return wrapWithMessage(1, &BadParameterError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -147,7 +147,7 @@ func IsBadParameter(e error) bool {
 
 // NotImplemented returns a new instance of NotImplementedError
 func NotImplemented(message string, args ...interface{}) Error {
-	return WrapWithMessage(&NotImplementedError{
+	return wrapWithMessage(1, &NotImplementedError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -184,7 +184,7 @@ func IsNotImplemented(e error) bool {
 
 // CompareFailed returns new instance of CompareFailedError
 func CompareFailed(message string, args ...interface{}) Error {
-	return WrapWithMessage(&CompareFailedError{Message: fmt.Sprintf(message, args...)}, message, args...)
+	return wrapWithMessage(1, &CompareFailedError{Message: fmt.Sprintf(message, args...)}, message, args...)
 }
 
 // CompareFailedError indicates a failed comparison (e.g. bad password or hash)
@@ -222,7 +222,7 @@ func IsCompareFailed(e error) bool {
 
 // AccessDenied returns new instance of AccessDeniedError
 func AccessDenied(message string, args ...interface{}) Error {
-	return WrapWithMessage(&AccessDeniedError{
+	return wrapWithMessage(1, &AccessDeniedError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -264,29 +264,29 @@ func ConvertSystemError(err error) error {
 	innerError := Unwrap(err)
 
 	if os.IsExist(innerError) {
-		return WrapWithMessage(&AlreadyExistsError{Message: innerError.Error()}, innerError.Error())
+		return wrapWithMessage(1, &AlreadyExistsError{Message: innerError.Error()}, innerError.Error())
 	}
 	if os.IsNotExist(innerError) {
-		return WrapWithMessage(&NotFoundError{Message: innerError.Error()}, innerError.Error())
+		return wrapWithMessage(1, &NotFoundError{Message: innerError.Error()}, innerError.Error())
 	}
 	if os.IsPermission(innerError) {
-		return WrapWithMessage(&AccessDeniedError{Message: innerError.Error()}, innerError.Error())
+		return wrapWithMessage(1, &AccessDeniedError{Message: innerError.Error()}, innerError.Error())
 	}
 	switch realErr := innerError.(type) {
 	case *net.OpError:
-		return WrapWithMessage(&ConnectionProblemError{
+		return wrapWithMessage(1, &ConnectionProblemError{
 			Message: realErr.Error(),
 			Err:     realErr}, realErr.Error())
 	case *os.PathError:
 		message := fmt.Sprintf("failed to execute command %v error:  %v", realErr.Path, realErr.Err)
-		return WrapWithMessage(&AccessDeniedError{
+		return wrapWithMessage(1, &AccessDeniedError{
 			Message: message,
 		}, message)
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
 		return newTrace(&TrustError{Err: innerError}, 2)
 	}
 	if _, ok := innerError.(net.Error); ok {
-		return WrapWithMessage(&ConnectionProblemError{
+		return wrapWithMessage(1, &ConnectionProblemError{
 			Message: innerError.Error(),
 			Err:     innerError}, innerError.Error())
 	}
@@ -295,7 +295,7 @@ func ConvertSystemError(err error) error {
 
 // ConnectionProblem returns new instance of ConnectionProblemError
 func ConnectionProblem(err error, message string, args ...interface{}) Error {
-	return WrapWithMessage(&ConnectionProblemError{
+	return wrapWithMessage(1, &ConnectionProblemError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
 	}, message, args...)
@@ -336,7 +336,7 @@ func IsConnectionProblem(e error) bool {
 
 // LimitExceeded returns whether new instance of LimitExceededError
 func LimitExceeded(message string, args ...interface{}) Error {
-	return WrapWithMessage(&LimitExceededError{
+	return wrapWithMessage(1, &LimitExceededError{
 		Message: fmt.Sprintf(message, args...),
 	}, message, args...)
 }
@@ -403,7 +403,7 @@ func IsTrustError(e error) bool {
 
 // OAuth2 returns new instance of OAuth2Error
 func OAuth2(code, message string, query url.Values) Error {
-	return WrapWithMessage(&OAuth2Error{
+	return wrapWithMessage(1, &OAuth2Error{
 		Code:    code,
 		Message: message,
 		Query:   query,
@@ -443,7 +443,7 @@ func IsEOF(e error) bool {
 
 // Retry return new instance of RetryError which indicates a transient error type
 func Retry(err error, message string, args ...interface{}) Error {
-	return WrapWithMessage(&RetryError{
+	return wrapWithMessage(1, &RetryError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
 	}, message, args...)

--- a/trace_test.go
+++ b/trace_test.go
@@ -48,6 +48,7 @@ func (s *TraceSuite) TestWrap(c *C) {
 	err := Wrap(Wrap(testErr))
 
 	c.Assert(line(DebugReport(err)), Matches, ".*trace_test.go.*")
+	c.Assert(line(DebugReport(err)), Not(Matches), ".*trace.go.*")
 	c.Assert(line(UserMessage(err)), Not(Matches), ".*trace_test.go.*")
 	c.Assert(line(UserMessage(err)), Matches, ".*param.*")
 }
@@ -68,9 +69,19 @@ func (s *TraceSuite) TestWrapUserMessage(c *C) {
 
 	err := Wrap(testErr, "user message")
 	c.Assert(line(UserMessage(err)), Equals, "user message")
+	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
+	c.Assert(line(DebugReport(err)), Not(Matches), "*.trace.go.*")
 
 	err = Wrap(err, "user message 2")
 	c.Assert(line(UserMessage(err)), Equals, "user message 2\tuser message")
+}
+
+func (s *TraceSuite) TestWrapWithMessage(c *C) {
+	testErr := fmt.Errorf("description")
+	err := WrapWithMessage(testErr, "user message")
+	c.Assert(line(UserMessage(err)), Equals, "user message")
+	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
+	c.Assert(line(DebugReport(err)), Not(Matches), "*.trace.go.*")
 }
 
 func (s *TraceSuite) TestUserMessageWithFields(c *C) {
@@ -379,6 +390,8 @@ func (s *TraceSuite) TestGenericErrors(c *C) {
 		}
 		c.Assert(len(traceErr.Traces), Not(Equals), 0, comment)
 		c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*", comment)
+		c.Assert(line(DebugReport(err)), Not(Matches), "*.errors.go.*", comment)
+		c.Assert(line(DebugReport(err)), Not(Matches), "*.trace.go.*", comment)
 		c.Assert(testCase.Predicate(err), Equals, true, comment)
 
 		w := newTestWriter()

--- a/trail/trail.go
+++ b/trail/trail.go
@@ -41,7 +41,6 @@ package trail
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 
 	"github.com/gravitational/trace"
 
@@ -122,23 +121,23 @@ func FromGRPC(err error, args ...interface{}) error {
 	case codes.OK:
 		return nil
 	case codes.NotFound:
-		e = &trace.NotFoundError{Message: message}
+		e = trace.InternalWrap(1, &trace.NotFoundError{Message: message})
 	case codes.AlreadyExists:
-		e = &trace.AlreadyExistsError{Message: message}
+		e = trace.InternalWrap(1, &trace.AlreadyExistsError{Message: message})
 	case codes.PermissionDenied:
-		e = &trace.AccessDeniedError{Message: message}
+		e = trace.InternalWrap(1, &trace.AccessDeniedError{Message: message})
 	case codes.FailedPrecondition:
-		e = &trace.CompareFailedError{Message: message}
+		e = trace.InternalWrap(1, &trace.CompareFailedError{Message: message})
 	case codes.InvalidArgument:
-		e = &trace.BadParameterError{Message: message}
+		e = trace.InternalWrap(1, &trace.BadParameterError{Message: message})
 	case codes.ResourceExhausted:
-		e = &trace.LimitExceededError{Message: message}
+		e = trace.InternalWrap(1, &trace.LimitExceededError{Message: message})
 	case codes.Unavailable:
-		e = &trace.ConnectionProblemError{Message: message}
+		e = trace.InternalWrap(1, &trace.ConnectionProblemError{Message: message})
 	case codes.Unimplemented:
-		e = &trace.NotImplementedError{Message: message}
+		e = trace.InternalWrap(1, &trace.NotImplementedError{Message: message})
 	default:
-		e = errors.New(message)
+		e = trace.InternalWrap(1, err)
 	}
 	if len(args) != 0 {
 		if meta, ok := args[0].(metadata.MD); ok {

--- a/trail/trail_test.go
+++ b/trail/trail_test.go
@@ -82,6 +82,8 @@ func (s *TrailSuite) TestConversion(c *C) {
 		c.Assert(grpc.ErrorDesc(grpcError), Equals, tc.Error.Error(), comment)
 		out := FromGRPC(grpcError)
 		c.Assert(tc.Predicate(out), Equals, true, comment)
+		c.Assert(line(trace.DebugReport(out)), Matches, ".*trail_test.go.*")
+		c.Assert(line(trace.DebugReport(out)), Not(Matches), ".*trail.go.*")
 	}
 }
 


### PR DESCRIPTION
Initial issue I was trying to solve is that in case of unknown error `trail.FromGRPC` rebuilds the error object from scratch. It leads to a problem that one cannot reason anymore what the original error it was.
For example one would want to check `trace.IsEOF(err)` on the result of `stream.Recv()` but io.EOF is not a GRPC error, so `trail.FromGRPC` treats it as unknown.

So in case of unknown error it's better to just wrap the original error.

But it'd be weird if some errors will be returned wrapped and some unwrapped. I think that `trail.FromGRPC` should return every error wrapped so stack trace will be included too which is the initial goal of the trace library.

Also I had to introduce some weird internal methods in order to have a control on how library captures the stack: trace caller should be on top of the stack without any frames from files like `trace.go`, `errors.go`, `trail.go`, etc. Added some tests asserting this.