### PR TITLE
Wrap GRPC errors to include stack trace

### DIFF
--- a/internal/frames.go
+++ b/internal/frames.go
@@ -1,0 +1,142 @@
+/*
+   Copyright 2021 Gravitational, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Trace stores structured trace entry, including file line and path
+type Trace struct {
+	// Path is a full file path
+	Path string `json:"path"`
+	// Func is a function name
+	Func string `json:"func"`
+	// Line is a code line number
+	Line int `json:"line"`
+}
+
+// FrameCursor stores the position in a call stack
+type FrameCursor struct {
+	// Current specifies the current stack frame.
+	// if omitted, rest contains the complete stack
+	Current *runtime.Frame
+	// Rest specifies the rest of stack frames to explore
+	Rest *runtime.Frames
+	// N specifies the total number of stack frames
+	N int
+}
+
+// Traces is a list of trace entries
+type Traces []Trace
+
+// CaptureTraces gets the current stack trace with some deep frames skipped
+func CaptureTraces(skip int) Traces {
+	var buf [32]uintptr
+	// +2 means that we also skip `CaptureTraces` and `runtime.Callers` frames.
+	n := runtime.Callers(skip+2, buf[:])
+	pcs := buf[:n]
+	frames := runtime.CallersFrames(pcs)
+	cursor := FrameCursor{
+		Rest: frames,
+		N:    n,
+	}
+	return GetTracesFromCursor(cursor)
+}
+
+// GetTracesFromCursor gets the current stack trace from a given cursor
+func GetTracesFromCursor(cursor FrameCursor) Traces {
+	traces := make(Traces, 0, cursor.N)
+	if cursor.Current != nil {
+		traces = append(traces, frameToTrace(*cursor.Current))
+	}
+	for i := 0; i < cursor.N; i++ {
+		frame, more := cursor.Rest.Next()
+		traces = append(traces, frameToTrace(frame))
+		if !more {
+			break
+		}
+	}
+	return traces
+}
+
+func frameToTrace(frame runtime.Frame) Trace {
+	return Trace{
+		Func: frame.Function,
+		Path: frame.File,
+		Line: frame.Line,
+	}
+}
+
+// SetTraces adds new traces to the list
+func (s Traces) SetTraces(traces ...Trace) {
+	s = append(s, traces...)
+}
+
+// Func returns first function in trace list
+func (s Traces) Func() string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0].Func
+}
+
+// Func returns just function name
+func (s Traces) FuncName() string {
+	if len(s) == 0 {
+		return ""
+	}
+	fn := filepath.ToSlash(s[0].Func)
+	idx := strings.LastIndex(fn, "/")
+	if idx == -1 || idx == len(fn)-1 {
+		return fn
+	}
+	return fn[idx+1:]
+}
+
+// Loc points to file/line location in the code
+func (s Traces) Loc() string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0].String()
+}
+
+// String returns debug-friendly representaton of trace stack
+func (s Traces) String() string {
+	if len(s) == 0 {
+		return ""
+	}
+	out := make([]string, len(s))
+	for i, t := range s {
+		out[i] = fmt.Sprintf("\t%v:%v %v", t.Path, t.Line, t.Func)
+	}
+	return strings.Join(out, "\n")
+}
+
+// String returns debug-friendly representation of this trace
+func (t *Trace) String() string {
+	dir, file := filepath.Split(t.Path)
+	dirs := strings.Split(filepath.ToSlash(filepath.Clean(dir)), "/")
+	if len(dirs) != 0 {
+		file = filepath.Join(dirs[len(dirs)-1], file)
+	}
+	return fmt.Sprintf("%v:%v", file, t.Line)
+}

--- a/trace_test.go
+++ b/trace_test.go
@@ -49,6 +49,7 @@ func (s *TraceSuite) TestWrap(c *C) {
 	err := Wrap(Wrap(testErr))
 
 	c.Assert(line(DebugReport(err)), Matches, ".*trace_test.go.*")
+	c.Assert(line(DebugReport(err)), Not(Matches), ".*trace.go.*")
 	c.Assert(line(UserMessage(err)), Not(Matches), ".*trace_test.go.*")
 	c.Assert(line(UserMessage(err)), Matches, ".*param.*")
 }
@@ -68,10 +69,20 @@ func (s *TraceSuite) TestWrapUserMessage(c *C) {
 	testErr := fmt.Errorf("description")
 
 	err := Wrap(testErr, "user message")
+	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
+	c.Assert(line(DebugReport(err)), Not(Matches), "*.trace.go.*")
 	c.Assert(line(UserMessage(err)), Equals, "user message\tdescription")
 
 	err = Wrap(err, "user message 2")
 	c.Assert(line(UserMessage(err)), Equals, "user message 2\tuser message\t\tdescription")
+}
+
+func (s *TraceSuite) TestWrapWithMessage(c *C) {
+	testErr := fmt.Errorf("description")
+	err := WrapWithMessage(testErr, "user message")
+	c.Assert(line(UserMessage(err)), Equals, "user message\tdescription")
+	c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*")
+	c.Assert(line(DebugReport(err)), Not(Matches), "*.trace.go.*")
 }
 
 func (s *TraceSuite) TestUserMessageWithFields(c *C) {
@@ -380,6 +391,8 @@ func (s *TraceSuite) TestGenericErrors(c *C) {
 		}
 		c.Assert(len(traceErr.Traces), Not(Equals), 0, comment)
 		c.Assert(line(DebugReport(err)), Matches, "*.trace_test.go.*", comment)
+		c.Assert(line(DebugReport(err)), Not(Matches), "*.errors.go.*", comment)
+		c.Assert(line(DebugReport(err)), Not(Matches), "*.trace.go.*", comment)
 		c.Assert(testCase.Predicate(err), Equals, true, comment)
 
 		w := newTestWriter()

--- a/udphook.go
+++ b/udphook.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/gravitational/trace/internal"
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
 )
@@ -68,7 +69,7 @@ func (elk *UDPHook) Fire(e *log.Entry) error {
 	// Make a copy to safely modify
 	entry := e.WithFields(nil)
 	if cursor := findFrame(); cursor != nil {
-		t := newTraceFromFrames(*cursor, nil)
+		t := internal.GetTracesFromCursor(*cursor)
 		entry.Data[FileField] = t.String()
 		entry.Data[FunctionField] = t.Func()
 	}


### PR DESCRIPTION
This is a rebuild of #54 with a stack frame stuff decoupled into
internal package.

GRPC errors must include stack trace as well as `trace.Wrape` errors.

Also `trail.FromGRPC(err)` wastes a structure of unknown errors that
leads to some surprising behavior:

```go
trace.IsEOF(trace.Wrap(io.EOF)) # true
trace.IsEOF(trail.FromGRPC(io.EOF)) # false
```