### PR TITLE
Delayed symbol decoding

### DIFF
--- a/httplib.go
+++ b/httplib.go
@@ -14,7 +14,7 @@ func WriteError(w http.ResponseWriter, err error) {
 		replyJSON(w, ErrorToCode(err), err)
 		return
 	}
-	for i := 0; i < maxHops; i++ {
+	for i := 0; i < internal.MaxHops; i++ {
 		var aggErr Aggregate
 		var ok bool
 		if aggErr, ok = Unwrap(err).(Aggregate); !ok {
@@ -127,6 +127,3 @@ func unmarshalError(err error, responseBody []byte) error {
 	json.Unmarshal(responseBody, err)
 	return err
 }
-
-// maxHops is a max supported nested depth for errors
-const maxHops = 50

--- a/internal/frames.go
+++ b/internal/frames.go
@@ -17,20 +17,186 @@ http://www.apache.org/licenses/LICENSE-2.0
 package internal
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"text/template"
 )
 
-// Trace stores structured trace entry, including file line and path
+// MarshalJSON marshals this error as JSON-encoded payload
+func (e *TraceErr) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return nil, nil
+	}
+	type marshalableError TraceErr
+	err := marshalableError(*e)
+	err.Err = &RawTrace{Message: e.Err.Error()}
+	err.Traces = e.Decode()
+	return json.Marshal(err)
+}
+
+// AddUserMessage adds user-friendly message describing the error nature
+func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr {
+	newMessage := fmt.Sprintf(fmt.Sprintf("%v", formatArg), rest...)
+	e.Messages = append(e.Messages, newMessage)
+	return e
+}
+
+// AddFields adds the given map of fields to the error being reported
+func (e *TraceErr) AddFields(fields map[string]interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, len(fields))
+	}
+	for k, v := range fields {
+		e.Fields[k] = v
+	}
+	return e
+}
+
+// AddField adds a single field to the error wrapper as context for the error
+func (e *TraceErr) AddField(k string, v interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, 1)
+	}
+	e.Fields[k] = v
+	return e
+}
+
+// UserMessage returns user-friendly error message
+func (e *TraceErr) UserMessage() string {
+	if len(e.Messages) > 0 {
+		// Format all collected messages in the reverse order, with each error
+		// on its own line with appropriate indentation so they form a tree and
+		// it's easy to see the cause and effect.
+		var buf bytes.Buffer
+		fmt.Fprintln(&buf, e.Messages[len(e.Messages)-1])
+		index, indent := len(e.Messages)-1, 1
+		for ; index > 0; index, indent = index-1, indent+1 {
+			fmt.Fprintf(&buf, "%v%v\n", strings.Repeat("\t", indent), e.Messages[index-1])
+		}
+		fmt.Fprintf(&buf, "%v%v", strings.Repeat("\t", indent), UserMessage(e.Err))
+		return buf.String()
+	}
+	if e.Message != "" {
+		// For backwards compatibility return the old user message if it's present.
+		return e.Message
+	}
+	return UserMessage(e.Err)
+}
+
+// DebugReport returns developer-friendly error report
+func (e *TraceErr) DebugReport() string {
+	var buf bytes.Buffer
+	err := reportTemplate.Execute(&buf, errorReport{
+		OrigErrType:    fmt.Sprintf("%T", e.Err),
+		OrigErrMessage: e.Err.Error(),
+		Fields:         e.Fields,
+		StackTrace:     e.Decode().String(),
+		UserMessage:    e.UserMessage(),
+	})
+	if err != nil {
+		return fmt.Sprint("error generating debug report: ", err.Error())
+	}
+	return buf.String()
+}
+
+// Error returns user-friendly error message when not in debug mode
+func (e *TraceErr) Error() string {
+	return e.UserMessage()
+}
+
+func (e *TraceErr) GetFields() map[string]interface{} {
+	return e.Fields
+}
+
+// Unwrap returns the error this TraceErr wraps. The returned error may also
+// wrap another one, Unwrap doesn't recursively get the inner-most error like
+// OrigError does.
+func (e *TraceErr) Unwrap() error {
+	return e.Err
+}
+
+// OrigError returns original wrapped error
+func (e *TraceErr) OrigError() error {
+	return e.Err
+}
+
+// GoString formats this trace object for use with
+// with the "%#v" format string
+func (e *TraceErr) GoString() string {
+	return e.DebugReport()
+}
+
+// Decode decodes symbolic debugging information from this error value
+func (e *TraceErr) Decode() Traces {
+	if len(e.Traces) != 0 {
+		return e.Traces
+	}
+	return e.traces.decode()
+}
+
+// TraceErr contains error message and some additional
+// information about the error origin
+type TraceErr struct {
+	// Err is the underlying error that TraceErr wraps
+	Err error `json:"error"`
+	// Traces optionally specified the decoded stack trace entries for the error.
+	Traces Traces `json:"traces,omitempty"`
+	// Message is an optional message that can be wrapped with the original error.
+	//
+	// This field is obsolete, replaced by messages list below.
+	Message string `json:"message,omitempty"`
+	// Messages is a list of user messages added to this error.
+	Messages []string `json:"messages,omitempty"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty"`
+
+	traces traces `json:"-"`
+}
+
+// Trace stores structured trace entry: source file line, file path and function name
 type Trace struct {
-	// Path is a full file path
+	// Path is the absolute file path
 	Path string `json:"path"`
-	// Func is a function name
+	// Func is the function name
 	Func string `json:"func"`
-	// Line is a code line number
+	// Line is the code line number
 	Line int `json:"line"`
+}
+
+// Error returns the error message this trace describes.
+// Implements error
+func (r *RawTrace) Error() string {
+	return r.Message
+}
+
+// Wrap translates this error value to an instance of TraceErr
+// wrapping the specified error
+func (r *RawTrace) Wrap(err error) *TraceErr {
+	return &TraceErr{
+		Traces:   r.Traces,
+		Err:      err,
+		Message:  r.Message,
+		Messages: r.Messages,
+		Fields:   r.Fields,
+	}
+}
+
+// RawTrace describes the error trace on the wire
+type RawTrace struct {
+	// Err specifies the original error
+	Err json.RawMessage `json:"error,omitempty"`
+	// Traces lists the stack traces at the moment the error was recorded
+	Traces Traces `json:"traces,omitempty"`
+	// Message specifies the optional user-facing message
+	Message string `json:"message,omitempty"`
+	// Messages is a list of user messages added to this error.
+	Messages []string `json:"messages,omitempty"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // FrameCursor stores the position in a call stack
@@ -47,22 +213,46 @@ type FrameCursor struct {
 // Traces is a list of trace entries
 type Traces []Trace
 
-// CaptureTraces gets the current stack trace with some deep frames skipped
-func CaptureTraces(skip int) Traces {
-	var buf [32]uintptr
-	// +2 means that we also skip `CaptureTraces` and `runtime.Callers` frames.
-	n := runtime.Callers(skip+2, buf[:])
-	pcs := buf[:n]
-	frames := runtime.CallersFrames(pcs)
-	cursor := FrameCursor{
-		Rest: frames,
-		N:    n,
+// DebugReport returns debug report with all known information
+// about the error including stack trace if it was captured
+func DebugReport(err error) string {
+	if err == nil {
+		return ""
 	}
-	return GetTracesFromCursor(cursor)
+	if reporter, ok := err.(DebugReporter); ok {
+		return reporter.DebugReport()
+	}
+	return err.Error()
 }
 
-// GetTracesFromCursor gets the current stack trace from a given cursor
-func GetTracesFromCursor(cursor FrameCursor) Traces {
+// UserMessage returns user-friendly part of the error
+func UserMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	if wrap, ok := err.(UserMessager); ok {
+		return wrap.UserMessage()
+	}
+	return err.Error()
+}
+
+// UserMessager returns a user message associated with the error
+type UserMessager interface {
+	// UserMessage returns the user message associated with the error if any
+	UserMessage() string
+}
+
+// Wrap returns a new instance of trace error at specified stack depth
+// for the given error
+func Wrap(err error, depth int) *TraceErr {
+	if err, ok := err.(*TraceErr); ok {
+		return err
+	}
+	return &TraceErr{Err: err, traces: captureTraces(depth)}
+}
+
+// DecodeTracesFromCursor decodes the stack trace from the given cursor
+func DecodeTracesFromCursor(cursor FrameCursor) Traces {
 	traces := make(Traces, 0, cursor.N)
 	if cursor.Current != nil {
 		traces = append(traces, frameToTrace(*cursor.Current))
@@ -76,6 +266,39 @@ func GetTracesFromCursor(cursor FrameCursor) Traces {
 	}
 	return traces
 }
+
+// ErrorWrapper wraps another error
+type ErrorWrapper interface {
+	// OrigError returns the wrapped error
+	OrigError() error
+}
+
+// DebugReporter formats an error for display
+type DebugReporter interface {
+	// DebugReport formats an error for display
+	DebugReport() string
+}
+
+// captureTraces captures the stack trace with skip frames omitted
+func captureTraces(skip int) traces {
+	var buf [32]uintptr
+	// +2 means that we also skip `captureTraces` and `runtime.Callers` frames.
+	n := runtime.Callers(skip+2, buf[:])
+	return buf[:n]
+}
+
+// decode decodes symbolic debugging information from this traces value
+func (r traces) decode() Traces {
+	frames := runtime.CallersFrames(r)
+	cursor := FrameCursor{
+		Rest: frames,
+		N:    len(r),
+	}
+	return DecodeTracesFromCursor(cursor)
+}
+
+// traces describes the call stack of an error
+type traces []uintptr
 
 func frameToTrace(frame runtime.Frame) Trace {
 	return Trace{
@@ -140,3 +363,84 @@ func (t *Trace) String() string {
 	}
 	return fmt.Sprintf("%v:%v", file, t.Line)
 }
+
+// WrapProxy wraps the specified error as a new error trace
+func WrapProxy(err error) *ProxyError {
+	if err == nil {
+		return nil
+	}
+	if err, ok := err.(*TraceErr); ok {
+		return &ProxyError{
+			TraceErr: err,
+		}
+	}
+	return &ProxyError{
+		// Do not include ReadError in the trace
+		TraceErr: Wrap(err, 3),
+	}
+}
+
+// DebugReport formats the underlying error for display
+// Implements DebugReporter
+func (r *ProxyError) DebugReport() string {
+	var wrappedErr *TraceErr
+	var ok bool
+	if wrappedErr, ok = r.TraceErr.Err.(*TraceErr); !ok {
+		return DebugReport(r.TraceErr)
+	}
+	var buf bytes.Buffer
+	//nolint:errcheck
+	reportTemplate.Execute(&buf, errorReport{
+		OrigErrType:    fmt.Sprintf("%T", wrappedErr.Err),
+		OrigErrMessage: wrappedErr.Err.Error(),
+		Fields:         wrappedErr.Fields,
+		StackTrace:     wrappedErr.Decode().String(),
+		UserMessage:    wrappedErr.UserMessage(),
+		Caught:         r.TraceErr.Decode().String(),
+	})
+	return buf.String()
+}
+
+// GoString formats this trace object for use with
+// with the "%#v" format string
+func (r *ProxyError) GoString() string {
+	return r.DebugReport()
+}
+
+func (r *ProxyError) OrigError() error {
+	return r.TraceErr.Err
+}
+
+// ProxyError wraps another error
+type ProxyError struct {
+	*TraceErr
+}
+
+type errorReport struct {
+	// OrigErrType specifies the error type as text
+	OrigErrType string
+	// OrigErrMessage specifies the original error's message
+	OrigErrMessage string
+	// Fields lists any additional fields attached to the error
+	Fields map[string]interface{}
+	// StackTrace specifies the call stack
+	StackTrace string
+	// UserMessage is the user-facing message (if any)
+	UserMessage string
+	// Caught optionally specifies the stack trace where the error
+	// has been recorded after coming over the wire
+	Caught string
+}
+
+var reportTemplate = template.Must(template.New("debugReport").Parse(reportTemplateText))
+var reportTemplateText = `
+ERROR REPORT:
+Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
+{{if .Fields}}Fields:
+{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
+{{end}}{{end}}Stack Trace:
+{{.StackTrace}}
+{{if .Caught}}Caught:
+{{.Caught}}
+User Message: {{.UserMessage}}
+{{else}}User Message: {{.UserMessage}}{{end}}`

--- a/log.go
+++ b/log.go
@@ -167,7 +167,7 @@ type JSONFormatter struct {
 // Format implements logrus.Formatter interface
 func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 	if cursor := findFrame(); cursor != nil {
-		t := internal.GetTracesFromCursor(*cursor)
+		t := internal.DecodeTracesFromCursor(*cursor)
 		new := e.WithFields(log.Fields{
 			FileField:     t.Loc(),
 			FunctionField: t.FuncName(),
@@ -184,7 +184,7 @@ func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 // for output in the log
 func formatCallerWithPathAndLine() (path string) {
 	if cursor := findFrame(); cursor != nil {
-		t := internal.GetTracesFromCursor(*cursor)
+		t := internal.DecodeTracesFromCursor(*cursor)
 		return t.Loc()
 	}
 	return ""
@@ -209,9 +209,8 @@ func findFrame() *internal.FrameCursor {
 		frame, _ := frames.Next()
 		if !frameIgnorePattern.MatchString(frame.File) {
 			return &internal.FrameCursor{
+				// Limit the stack trace to the first matching frame
 				Current: &frame,
-				Rest:    frames,
-				N:       n,
 			}
 		}
 	}

--- a/trace.go
+++ b/trace.go
@@ -144,36 +144,10 @@ type Traces = internal.Traces
 
 type TraceErr = internal.TraceErr
 
+type Error = internal.Error
+
 // Fields maps arbitrary keys to values inside an error
 type Fields map[string]interface{}
-
-// Error is an interface that helps to adapt usage of trace in the code
-// When applications define new error types, they can implement the interface
-//
-// Error handlers can use Unwrap() to retrieve error from the wrapper, or
-// errors.Is()/As() to compare it to another value.
-type Error interface {
-	error
-	ErrorWrapper
-	DebugReporter
-	UserMessager
-
-	// AddMessage adds formatted user-facing message
-	// to the error, depends on the implementation,
-	// usually works as fmt.Sprintf(formatArg, rest...)
-	// but implementations can choose another way, e.g. treat
-	// arguments as structured args
-	AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr
-
-	// AddField adds additional field information to the error
-	AddField(key string, value interface{}) *TraceErr
-
-	// AddFields adds a map of additional fields to the error
-	AddFields(fields map[string]interface{}) *TraceErr
-
-	// GetFields returns any fields that have been added to the error
-	GetFields() map[string]interface{}
-}
 
 // NewAggregate creates a new aggregate instance from the specified
 // list of errors

--- a/trace.go
+++ b/trace.go
@@ -76,6 +76,7 @@ var DebugReport = internal.DebugReport
 type UserMessager = internal.UserMessager
 type ErrorWrapper = internal.ErrorWrapper
 type DebugReporter = internal.DebugReporter
+type RawTrace = internal.RawTrace
 
 // UserMessageWithFields returns user-friendly error with key-pairs as part of the message
 func UserMessageWithFields(err error) string {

--- a/trace.go
+++ b/trace.go
@@ -142,8 +142,8 @@ func newTrace(err error, depth int) *TraceErr {
 }
 
 type Traces = internal.Traces
-
 type TraceErr = internal.TraceErr
+type Trace = internal.Trace
 
 type Error = internal.Error
 

--- a/trace.go
+++ b/trace.go
@@ -19,10 +19,7 @@ limitations under the License.
 package trace
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"html/template"
 	"strings"
 	"sync/atomic"
 
@@ -73,34 +70,12 @@ func Unwrap(err error) error {
 	return err
 }
 
-// UserMessager returns a user message associated with the error
-type UserMessager interface {
-	// UserMessage returns the user message associated with the error if any
-	UserMessage() string
-}
+var UserMessage = internal.UserMessage
+var DebugReport = internal.DebugReport
 
-// ErrorWrapper wraps another error
-type ErrorWrapper interface {
-	// OrigError returns the wrapped error
-	OrigError() error
-}
-
-// DebugReporter formats an error for display
-type DebugReporter interface {
-	// DebugReport formats an error for display
-	DebugReport() string
-}
-
-// UserMessage returns user-friendly part of the error
-func UserMessage(err error) string {
-	if err == nil {
-		return ""
-	}
-	if wrap, ok := err.(UserMessager); ok {
-		return wrap.UserMessage()
-	}
-	return err.Error()
-}
+type UserMessager = internal.UserMessager
+type ErrorWrapper = internal.ErrorWrapper
+type DebugReporter = internal.DebugReporter
 
 // UserMessageWithFields returns user-friendly error with key-pairs as part of the message
 func UserMessageWithFields(err error) string {
@@ -117,18 +92,6 @@ func UserMessageWithFields(err error) string {
 			kvps = append(kvps, fmt.Sprintf("%v=%q", k, v))
 		}
 		return fmt.Sprintf("%v %v", strings.Join(kvps, " "), wrap.UserMessage())
-	}
-	return err.Error()
-}
-
-// DebugReport returns debug report with all known information
-// about the error including stack trace if it was captured
-func DebugReport(err error) string {
-	if err == nil {
-		return ""
-	}
-	if reporter, ok := err.(DebugReporter); ok {
-		return reporter.DebugReport()
 	}
 	return err.Error()
 }
@@ -169,180 +132,20 @@ func Errorf(format string, args ...interface{}) (err error) {
 func Fatalf(format string, args ...interface{}) error {
 	if IsDebug() {
 		panic(fmt.Sprintf(format, args...))
-	} else {
-		return Errorf(format, args...)
 	}
+	return Errorf(format, args...)
 }
 
 func newTrace(err error, depth int) *TraceErr {
-	traces := internal.CaptureTraces(depth)
-	return &TraceErr{Err: err, Traces: traces}
+	return internal.Wrap(err, depth+1)
 }
 
 type Traces = internal.Traces
 
-type Trace = internal.Trace
-
-// MarshalJSON marshals this error as JSON-encoded payload
-func (r *TraceErr) MarshalJSON() ([]byte, error) {
-	if r == nil {
-		return nil, nil
-	}
-	type marshalableError TraceErr
-	err := marshalableError(*r)
-	err.Err = &RawTrace{Message: r.Err.Error()}
-	return json.Marshal(err)
-}
-
-// TraceErr contains error message and some additional
-// information about the error origin
-type TraceErr struct {
-	// Err is the underlying error that TraceErr wraps
-	Err error `json:"error"`
-	// Traces is a slice of stack trace entries for the error
-	Traces `json:"traces,omitempty"`
-	// Message is an optional message that can be wrapped with the original error.
-	//
-	// This field is obsolete, replaced by messages list below.
-	Message string `json:"message,omitempty"`
-	// Messages is a list of user messages added to this error.
-	Messages []string `json:"messages,omitempty"`
-	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
-	Fields map[string]interface{} `json:"fields,omitempty"`
-}
+type TraceErr = internal.TraceErr
 
 // Fields maps arbitrary keys to values inside an error
 type Fields map[string]interface{}
-
-// Error returns the error message this trace describes.
-// Implements error
-func (r *RawTrace) Error() string {
-	return r.Message
-}
-
-// RawTrace describes the error trace on the wire
-type RawTrace struct {
-	// Err specifies the original error
-	Err json.RawMessage `json:"error,omitempty"`
-	// Traces lists the stack traces at the moment the error was recorded
-	Traces `json:"traces,omitempty"`
-	// Message specifies the optional user-facing message
-	Message string `json:"message,omitempty"`
-	// Messages is a list of user messages added to this error.
-	Messages []string `json:"messages,omitempty"`
-	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
-	Fields map[string]interface{} `json:"fields,omitempty"`
-}
-
-// AddUserMessage adds user-friendly message describing the error nature
-func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr {
-	newMessage := fmt.Sprintf(fmt.Sprintf("%v", formatArg), rest...)
-	e.Messages = append(e.Messages, newMessage)
-	return e
-}
-
-// AddFields adds the given map of fields to the error being reported
-func (e *TraceErr) AddFields(fields map[string]interface{}) *TraceErr {
-	if e.Fields == nil {
-		e.Fields = make(map[string]interface{}, len(fields))
-	}
-	for k, v := range fields {
-		e.Fields[k] = v
-	}
-	return e
-}
-
-// AddField adds a single field to the error wrapper as context for the error
-func (e *TraceErr) AddField(k string, v interface{}) *TraceErr {
-	if e.Fields == nil {
-		e.Fields = make(map[string]interface{}, 1)
-	}
-	e.Fields[k] = v
-	return e
-}
-
-// UserMessage returns user-friendly error message
-func (e *TraceErr) UserMessage() string {
-	if len(e.Messages) > 0 {
-		// Format all collected messages in the reverse order, with each error
-		// on its own line with appropriate indentation so they form a tree and
-		// it's easy to see the cause and effect.
-		var buf bytes.Buffer
-		fmt.Fprintln(&buf, e.Messages[len(e.Messages)-1])
-		index, indent := len(e.Messages)-1, 1
-		for ; index > 0; index, indent = index-1, indent+1 {
-			fmt.Fprintf(&buf, "%v%v\n", strings.Repeat("\t", indent), e.Messages[index-1])
-		}
-		fmt.Fprintf(&buf, "%v%v", strings.Repeat("\t", indent), UserMessage(e.Err))
-		return buf.String()
-	}
-	if e.Message != "" {
-		// For backwards compatibility return the old user message if it's present.
-		return e.Message
-	}
-	return UserMessage(e.Err)
-}
-
-// DebugReport returns developer-friendly error report
-func (e *TraceErr) DebugReport() string {
-	var buf bytes.Buffer
-	err := reportTemplate.Execute(&buf, errorReport{
-		OrigErrType:    fmt.Sprintf("%T", e.Err),
-		OrigErrMessage: e.Err.Error(),
-		Fields:         e.Fields,
-		StackTrace:     e.Traces.String(),
-		UserMessage:    e.UserMessage(),
-	})
-	if err != nil {
-		return fmt.Sprint("error generating debug report: ", err.Error())
-	}
-	return buf.String()
-}
-
-// Error returns user-friendly error message when not in debug mode
-func (e *TraceErr) Error() string {
-	return e.UserMessage()
-}
-
-func (e *TraceErr) GetFields() map[string]interface{} {
-	return e.Fields
-}
-
-// Unwrap returns the error this TraceErr wraps. The returned error may also
-// wrap another one, Unwrap doesn't recursively get the inner-most error like
-// OrigError does.
-func (e *TraceErr) Unwrap() error {
-	return e.Err
-}
-
-// OrigError returns original wrapped error
-func (e *TraceErr) OrigError() error {
-	err := e.Err
-	// this is not an endless loop because I'm being
-	// paranoid, this is a safe protection against endless
-	// loops
-	for i := 0; i < maxHops; i++ {
-		newerr, ok := err.(Error)
-		if !ok {
-			break
-		}
-		next := newerr.OrigError()
-		if next == nil || next == err {
-			break
-		}
-		err = next
-	}
-	return err
-}
-
-// GoString formats this trace object for use with
-// with the "%#v" format string
-func (e *TraceErr) GoString() string {
-	return e.DebugReport()
-}
-
-// maxHops is a max supported nested depth for errors
-const maxHops = 50
 
 // Error is an interface that helps to adapt usage of trace in the code
 // When applications define new error types, they can implement the interface
@@ -444,75 +247,3 @@ func IsAggregate(err error) bool {
 	_, ok := Unwrap(err).(Aggregate)
 	return ok
 }
-
-// wrapProxy wraps the specified error as a new error trace
-func wrapProxy(err error) Error {
-	if err == nil {
-		return nil
-	}
-	return proxyError{
-		// Do not include ReadError in the trace
-		TraceErr: newTrace(err, 3),
-	}
-}
-
-// DebugReport formats the underlying error for display
-// Implements DebugReporter
-func (r proxyError) DebugReport() string {
-	var wrappedErr *TraceErr
-	var ok bool
-	if wrappedErr, ok = r.TraceErr.Err.(*TraceErr); !ok {
-		return DebugReport(r.TraceErr)
-	}
-	var buf bytes.Buffer
-	//nolint:errcheck
-	reportTemplate.Execute(&buf, errorReport{
-		OrigErrType:    fmt.Sprintf("%T", wrappedErr.Err),
-		OrigErrMessage: wrappedErr.Err.Error(),
-		Fields:         wrappedErr.Fields,
-		StackTrace:     wrappedErr.Traces.String(),
-		UserMessage:    wrappedErr.UserMessage(),
-		Caught:         r.TraceErr.Traces.String(),
-	})
-	return buf.String()
-}
-
-// GoString formats this trace object for use with
-// with the "%#v" format string
-func (r proxyError) GoString() string {
-	return r.DebugReport()
-}
-
-// proxyError wraps another error
-type proxyError struct {
-	*TraceErr
-}
-
-type errorReport struct {
-	// OrigErrType specifies the error type as text
-	OrigErrType string
-	// OrigErrMessage specifies the original error's message
-	OrigErrMessage string
-	// Fields lists any additional fields attached to the error
-	Fields map[string]interface{}
-	// StackTrace specifies the call stack
-	StackTrace string
-	// UserMessage is the user-facing message (if any)
-	UserMessage string
-	// Caught optionally specifies the stack trace where the error
-	// has been recorded after coming over the wire
-	Caught string
-}
-
-var reportTemplate = template.Must(template.New("debugReport").Parse(reportTemplateText))
-var reportTemplateText = `
-ERROR REPORT:
-Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
-{{if .Fields}}Fields:
-{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
-{{end}}{{end}}Stack Trace:
-{{.StackTrace}}
-{{if .Caught}}Caught:
-{{.Caught}}
-User Message: {{.UserMessage}}
-{{else}}User Message: {{.UserMessage}}{{end}}`

--- a/trace_test.go
+++ b/trace_test.go
@@ -428,7 +428,8 @@ func (s *TraceSuite) TestWriteExternalErrors(c *C) {
 	WriteError(w, err)
 	extErr = ReadError(w.StatusCode, w.Body)
 	c.Assert(w.StatusCode, Equals, http.StatusInternalServerError)
-	c.Assert(strings.Replace(string(w.Body), "\n", "", -1), Matches, "*.snap.*")
+	c.Assert(string(w.Body), Matches, "(?s).*snap.*")
+	c.Assert(DebugReport(extErr), Matches, "(?s).*Caught:.*")
 	c.Assert(err.Error(), Equals, extErr.Error())
 }
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -677,6 +677,7 @@ func TestStdlibCompat(t *testing.T) {
 }
 
 func BenchmarkStacktraceAllocs(b *testing.B) {
+	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		Wrap(Errorf("example error"))
 	}

--- a/udphook.go
+++ b/udphook.go
@@ -69,7 +69,7 @@ func (elk *UDPHook) Fire(e *log.Entry) error {
 	// Make a copy to safely modify
 	entry := e.WithFields(nil)
 	if cursor := findFrame(); cursor != nil {
-		t := internal.GetTracesFromCursor(*cursor)
+		t := internal.DecodeTracesFromCursor(*cursor)
 		entry.Data[FileField] = t.String()
 		entry.Data[FunctionField] = t.Func()
 	}


### PR DESCRIPTION
This PR implements delayed decoding of debug symbols to lower the memory allocations and speed up error value creation in the basic wrapping scenario. The symbols are decoded when necessary (e.g. on DebugReport or upon being written to the wire).

Before the change
```
$ go test -bench=. -benchmem ./...
OK: 29 passed
goos: linux
goarch: amd64
pkg: github.com/gravitational/trace
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
BenchmarkStacktraceAllocs-16    	  642918	      1574 ns/op	     779 B/op	       6 allocs/op
```

After the change:
```
$ go test -bench=. -benchmem ./...
OK: 29 passed
goos: linux
goarch: amd64
pkg: github.com/gravitational/trace
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
BenchmarkStacktraceAllocs-16    	 1348497	       829.1 ns/op	     400 B/op	       4 allocs/op
```

```
$ benchstat old.txt new.txt 
name                 old time/op    new time/op    delta
StacktraceAllocs-16    1.57µs ± 0%    0.83µs ± 0%   ~     (p=1.000 n=1+1)

name                 old alloc/op   new alloc/op   delta
StacktraceAllocs-16      779B ± 0%      400B ± 0%   ~     (p=1.000 n=1+1)

name                 old allocs/op  new allocs/op  delta
StacktraceAllocs-16      6.00 ± 0%      4.00 ± 0%   ~     (p=1.000 n=1+1)
```