### PR TITLE
trail: preserve grpc status code in ToGRPC

### DIFF
--- a/trail/trail.go
+++ b/trail/trail.go
@@ -49,6 +49,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // Send is a high level function that:
@@ -81,6 +82,11 @@ func ToGRPC(err error) error {
 	if err == nil {
 		return nil
 	}
+	// If err is already a gRPC error, don't modify it.
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
 	userMessage := trace.UserMessage(err)
 	if trace.IsNotFound(err) {
 		return grpc.Errorf(codes.NotFound, userMessage)

--- a/trail/trail_test.go
+++ b/trail/trail_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	. "gopkg.in/check.v1"
 )
 
@@ -112,4 +114,16 @@ func (s *TrailSuite) TestTraces(c *C) {
 
 func line(s string) string {
 	return strings.Replace(s, "\n", "", -1)
+}
+
+func TestToGRPCKeepCode(t *testing.T) {
+	err := status.Errorf(codes.PermissionDenied, "denied")
+	err = ToGRPC(err)
+	if code := status.Code(err); code != codes.PermissionDenied {
+		t.Errorf("after ToGRPC, got error code %v, want %v, error: %v", code, codes.PermissionDenied, err)
+	}
+	err = FromGRPC(err)
+	if !trace.IsAccessDenied(err) {
+		t.Errorf("after FromGRPC, trace.IsAccessDenied is false, want true, error: %v", err)
+	}
 }


### PR DESCRIPTION
If the error passed to `trail.ToGRPC` is already a gRPC error with a
status code, return it as is instead of overwriting with
`status.Unknown`.