### PR TITLE
Hide stacktrace from HTTP response

### DIFF
--- a/httplib.go
+++ b/httplib.go
@@ -94,10 +94,6 @@ func replyJSON(w http.ResponseWriter, code int, err error) {
 	if !ok {
 		obj = &TraceErr{Err: err}
 	}
-	// Don't leak the stack trace
-	if !IsDebug() {
-		obj.Traces = Traces{}
-	}
 	out, err = json.MarshalIndent(obj, "", "    ")
 	if err != nil {
 		out = []byte(fmt.Sprintf(`{"error": {"message": "internal marshal error: %v"}}`, err))

--- a/httplib.go
+++ b/httplib.go
@@ -90,9 +90,13 @@ func replyJSON(w http.ResponseWriter, code int, err error) {
 	var out []byte
 	// wrap regular errors in order to achieve unification
 	// and provide structurally consistent responses
-	var obj interface{} = err
-	if _, ok := err.(*TraceErr); !ok {
+	obj, ok := err.(*TraceErr)
+	if !ok {
 		obj = &TraceErr{Err: err}
+	}
+	// Don't leak the stack trace
+	if !IsDebug() {
+		obj.Traces = Traces{}
 	}
 	out, err = json.MarshalIndent(obj, "", "    ")
 	if err != nil {

--- a/httplib_test.go
+++ b/httplib_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestReplyJSON(t *testing.T) {
-	t.Parallel()
+	SetDebug(false)
 	var (
 		errCode               = 400
 		errText               = "test error"
@@ -45,6 +45,7 @@ func TestReplyJSON(t *testing.T) {
 
 	testCase(t, errors.New("test error"))
 	testCase(t, &TraceErr{Err: errors.New("test error")})
+	testCase(t, &TraceErr{Err: errors.New("test error"), Traces: Traces{{Path: "A", Func: "B", Line: 1}}})
 }
 
 func TestUnmarshalError(t *testing.T) {

--- a/httplib_test.go
+++ b/httplib_test.go
@@ -45,7 +45,6 @@ func TestReplyJSON(t *testing.T) {
 		{"trace error", &TraceErr{Err: errors.New("test error")}},
 		{"trace error with stacktrace", &TraceErr{Err: errors.New("test error"), Traces: Traces{{Path: "A", Func: "B", Line: 1}}}},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			replyJSON(recorder, errCode, tc.err)

--- a/httplib_test.go
+++ b/httplib_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestReplyJSON(t *testing.T) {
-	t.Parallel()
 	var (
 		errCode               = 400
 		errText               = "test error"
@@ -37,15 +36,22 @@ func TestReplyJSON(t *testing.T) {
 			"}"
 	)
 
-	testCase := func(t *testing.T, err error) {
-		recorder := httptest.NewRecorder()
-		replyJSON(recorder, errCode, err)
-		require.Equal(t, expectedErrorResponse, recorder.Body.String())
+	for _, tc := range []struct {
+		desc string
+		err  error
+	}{
+		{"plain error", errors.New("test error")},
+		{"trace error", &TraceErr{Err: errors.New("test error")}},
+		{"trace error with stacktrace", &TraceErr{Err: errors.New("test error"), Traces: Traces{{Path: "A", Func: "B", Line: 1}}}},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			recorder := httptest.NewRecorder()
+			replyJSON(recorder, errCode, tc.err)
+			require.JSONEq(t, expectedErrorResponse, recorder.Body.String())
+		})
 	}
-
-	testCase(t, errors.New("test error"))
-	testCase(t, &TraceErr{Err: errors.New("test error")})
-	testCase(t, &TraceErr{Err: errors.New("test error"), Traces: Traces{{Path: "A", Func: "B", Line: 1}}})
 }
 
 func TestUnmarshalError(t *testing.T) {

--- a/httplib_test.go
+++ b/httplib_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestReplyJSON(t *testing.T) {
-	SetDebug(false)
+	t.Parallel()
 	var (
 		errCode               = 400
 		errText               = "test error"

--- a/httplib_test.go
+++ b/httplib_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestReplyJSON(t *testing.T) {
+	t.Parallel()
 	var (
 		errCode               = 400
 		errText               = "test error"
@@ -46,7 +47,6 @@ func TestReplyJSON(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
 			recorder := httptest.NewRecorder()
 			replyJSON(recorder, errCode, tc.err)
 			require.JSONEq(t, expectedErrorResponse, recorder.Body.String())

--- a/trace.go
+++ b/trace.go
@@ -200,7 +200,7 @@ type TraceErr struct {
 	// Err is the underlying error that TraceErr wraps
 	Err error `json:"error"`
 	// Traces is a slice of stack trace entries for the error
-	Traces `json:"traces,omitempty"`
+	Traces `json:"-"`
 	// Message is an optional message that can be wrapped with the original error.
 	//
 	// This field is obsolete, replaced by messages list below.


### PR DESCRIPTION
This PR prevents trace from leaking stack traces in HTTP responses (unless the server is in debug mode). Addresses gravitational/teleport.e#282.