### PR TITLE
Use frame.Function to determine caller.

### DIFF
--- a/log.go
+++ b/log.go
@@ -190,7 +190,7 @@ func formatCallerWithPathAndLine() (path string) {
 	return ""
 }
 
-var frameIgnorePattern = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
+var frameIgnorePattern = regexp.MustCompile(`github\.com/sirupsen/logrus`)
 
 // findFrames positions the stack pointer to the first
 // function that does not match the frameIngorePattern
@@ -207,7 +207,7 @@ func findFrame() *internal.FrameCursor {
 	frames := runtime.CallersFrames(pcs)
 	for i := 0; i < n; i++ {
 		frame, _ := frames.Next()
-		if !frameIgnorePattern.MatchString(frame.File) {
+		if !frameIgnorePattern.MatchString(frame.Function) {
 			return &internal.FrameCursor{
 				Current: &frame,
 				Rest:    frames,


### PR DESCRIPTION
Current logic to determine a caller frame doesn't work with do modules when logrus is forked. With `vendor` directory (even with replace) logrus is always copied to `vendor/github.com/sirupsen/logrus`. Our regex is working in this case, but go modules checkout the repository to a directory using the fork name, ex `${GOPATH}/pkg/mod/github.com/gravitational/logrus@...` which won't match our regex. The simplest solution is use `frame.Function` as the name is preserved and always contains `github.com/sirupsen/logrus`.

I've also removed the `Sirupsen` from our regex as by now all our dependencies migrated to the newer version.