### PR TITLE
Validate error contents are equivalent in Is

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -57,7 +57,16 @@ func (e *NotFoundError) OrigError() error {
 
 // Is provides an equivalency check for NotFoundError to be used with errors.Is
 func (e *NotFoundError) Is(target error) bool {
-	return IsNotFound(target)
+	if os.IsNotExist(target) {
+		return true
+	}
+
+	err, ok := Unwrap(target).(*NotFoundError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == e.Message
 }
 
 // IsNotFound returns whether this error is of NotFoundError type
@@ -105,7 +114,12 @@ func (e *AlreadyExistsError) OrigError() error {
 
 // Is provides an equivalency check for AlreadyExistsError to be used with errors.Is
 func (e *AlreadyExistsError) Is(target error) bool {
-	return IsAlreadyExists(target)
+	err, ok := Unwrap(target).(*AlreadyExistsError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == e.Message
 }
 
 // IsAlreadyExists returns whether this is error indicating that object
@@ -148,7 +162,12 @@ func (b *BadParameterError) IsBadParameterError() bool {
 
 // Is provides an equivalency check for BadParameterError to be used with errors.Is
 func (b *BadParameterError) Is(target error) bool {
-	return IsBadParameter(target)
+	err, ok := Unwrap(target).(*BadParameterError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == b.Message
 }
 
 // IsBadParameter returns whether this error is of BadParameterType
@@ -190,7 +209,12 @@ func (e *NotImplementedError) IsNotImplementedError() bool {
 
 // Is provides an equivalency check for NotImplementedError to be used with errors.Is
 func (e *NotImplementedError) Is(target error) bool {
-	return IsNotImplemented(target)
+	err, ok := Unwrap(target).(*NotImplementedError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == e.Message
 }
 
 // IsNotImplemented returns whether this error is of NotImplementedError type
@@ -235,7 +259,12 @@ func (e *CompareFailedError) IsCompareFailedError() bool {
 
 // Is provides an equivalency check for CompareFailedError to be used with errors.Is
 func (e *CompareFailedError) Is(target error) bool {
-	return IsCompareFailed(target)
+	err, ok := Unwrap(target).(*CompareFailedError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == e.Message
 }
 
 // IsCompareFailed detects if this error is of CompareFailed type
@@ -279,7 +308,12 @@ func (e *AccessDeniedError) OrigError() error {
 
 // Is provides an equivalency check for AccessDeniedError to be used with errors.Is
 func (e *AccessDeniedError) Is(target error) bool {
-	return IsAccessDenied(target)
+	err, ok := Unwrap(target).(*AccessDeniedError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == e.Message
 }
 
 // IsAccessDenied detects if this error is of AccessDeniedError type
@@ -373,7 +407,12 @@ func (c *ConnectionProblemError) OrigError() error {
 
 // Is provides an equivalency check for ConnectionProblemError to be used with errors.Is
 func (c *ConnectionProblemError) Is(target error) bool {
-	return IsConnectionProblem(target)
+	err, ok := Unwrap(target).(*ConnectionProblemError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == c.Message && err.Err == c.Err
 }
 
 // IsConnectionProblem returns whether this error is of ConnectionProblemError
@@ -414,7 +453,12 @@ func (e *LimitExceededError) OrigError() error {
 
 // Is provides an equivalency check for LimitExceededError to be used with errors.Is
 func (e *LimitExceededError) Is(target error) bool {
-	return IsLimitExceeded(target)
+	err, ok := Unwrap(target).(*LimitExceededError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == e.Message
 }
 
 // IsLimitExceeded detects if this error is of LimitExceededError
@@ -469,7 +513,12 @@ func (t *TrustError) OrigError() error {
 
 // Is provides an equivalency check for TrustError to be used with errors.Is
 func (t *TrustError) Is(target error) bool {
-	return IsTrustError(target)
+	err, ok := Unwrap(target).(*TrustError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == t.Message && err.Err == t.Err
 }
 
 // IsTrustError returns if this is a trust error
@@ -509,7 +558,32 @@ func (o *OAuth2Error) IsOAuth2Error() bool {
 
 // Is provides an equivalency check for OAuth2Error to be used with errors.Is
 func (o *OAuth2Error) Is(target error) bool {
-	return IsOAuth2(target)
+	err, ok := Unwrap(target).(*OAuth2Error)
+	if !ok {
+		return false
+	}
+
+	if err.Message != o.Message ||
+		err.Code != o.Code ||
+		len(err.Query) != len(o.Query) {
+		return false
+	}
+
+	for k, v := range err.Query {
+		for k2, v2 := range o.Query {
+			if k != k2 && len(v) != len(v2) {
+				return false
+			}
+
+			for i := range v {
+				if v[i] != v2[i] {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
 }
 
 // IsOAuth2 returns if this is a OAuth2-related error
@@ -568,7 +642,12 @@ func (c *RetryError) OrigError() error {
 
 // Is provides an equivalency check for RetryError to be used with errors.Is
 func (c *RetryError) Is(target error) bool {
-	return IsRetryError(target)
+	err, ok := Unwrap(target).(*RetryError)
+	if !ok {
+		return false
+	}
+
+	return err.Message == c.Message && err.Err == c.Err
 }
 
 // IsRetryError returns whether this error is of ConnectionProblemError

--- a/errors_test.go
+++ b/errors_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func Test_Is(t *testing.T) {
-
 	type testError struct {
 		err  error
 		name string
@@ -38,7 +37,7 @@ func Test_Is(t *testing.T) {
 	cases := map[error][]testError{
 		&NotFoundError{}: {
 			{
-				err:  NotFound("test"),
+				err:  NotFound(""),
 				name: "NotFound",
 			}, {
 				err:  os.ErrNotExist,
@@ -47,61 +46,61 @@ func Test_Is(t *testing.T) {
 		},
 		&BadParameterError{}: {
 			{
-				err:  BadParameter("test"),
+				err:  BadParameter(""),
 				name: "BadParameter",
 			},
 		},
 		&RetryError{}: {
 			{
-				err:  Retry(io.EOF, "test"),
+				err:  Retry(nil, ""),
 				name: "Retry",
 			},
 		},
 		&OAuth2Error{}: {
 			{
-				err:  OAuth2("test", "test", url.Values{}),
+				err:  OAuth2("", "", url.Values{}),
 				name: "OAuth2",
 			},
 		},
 		&TrustError{}: {
 			{
-				err:  Trust(io.EOF, "test"),
+				err:  Trust(nil, ""),
 				name: "Trust",
 			},
 		},
 		&LimitExceededError{}: {
 			{
-				err:  LimitExceeded("test"),
+				err:  LimitExceeded(""),
 				name: "LimitExceeded",
 			},
 		},
 		&ConnectionProblemError{}: {
 			{
-				err:  ConnectionProblem(io.EOF, "test"),
+				err:  ConnectionProblem(nil, ""),
 				name: "ConnectionProblem",
 			},
 		},
 		&AccessDeniedError{}: {
 			{
-				err:  AccessDenied("test"),
+				err:  AccessDenied(""),
 				name: "AccessDenied",
 			},
 		},
 		&CompareFailedError{}: {
 			{
-				err:  CompareFailed("test"),
+				err:  CompareFailed(""),
 				name: "CompareFailed",
 			},
 		},
 		&NotImplementedError{}: {
 			{
-				err:  NotImplemented("test"),
+				err:  NotImplemented(""),
 				name: "NotImplemented",
 			},
 		},
 		&AlreadyExistsError{}: {
 			{
-				err:  AlreadyExists("test"),
+				err:  AlreadyExists(""),
 				name: "AlreadyExists",
 			},
 		},
@@ -163,4 +162,216 @@ func Test_Is(t *testing.T) {
 		})
 	}
 
+}
+
+func TestNotFoundError_Is(t *testing.T) {
+	errs := []error{
+		NotFound("one"),
+		NotFound("two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+		require.ErrorIs(t, errs[i], os.ErrNotExist)
+		require.NotErrorIs(t, os.ErrNotExist, errs[i])
+	}
+}
+
+func TestAlreadyExistsError_Is(t *testing.T) {
+	errs := []error{
+		AlreadyExists("one"),
+		AlreadyExists("two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestBadParameterError_Is(t *testing.T) {
+	errs := []error{
+		BadParameter("one"),
+		BadParameter("two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestIsNotImplementedError_Is(t *testing.T) {
+	errs := []error{
+		NotImplemented("one"),
+		NotImplemented("two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestCompareFailedError_Is(t *testing.T) {
+	errs := []error{
+		CompareFailed("one"),
+		CompareFailed("two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestAccessDeniedError_Is(t *testing.T) {
+	errs := []error{
+		AccessDenied("one"),
+		AccessDenied("two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestConnectionProblemError_Is(t *testing.T) {
+	errs := []error{
+		ConnectionProblem(io.EOF, "one"),
+		ConnectionProblem(os.ErrNotExist, "one"),
+		ConnectionProblem(io.EOF, "two"),
+		ConnectionProblem(os.ErrNotExist, "two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestLimitExceededError_Is(t *testing.T) {
+	errs := []error{
+		LimitExceeded("one"),
+		LimitExceeded("two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestTrustError_Is(t *testing.T) {
+	errs := []error{
+		Trust(io.EOF, "one"),
+		Trust(os.ErrNotExist, "one"),
+		Trust(io.EOF, "two"),
+		Trust(os.ErrNotExist, "two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestOauth2Error_Is(t *testing.T) {
+	errs := []error{
+		OAuth2("a", "one", nil),
+		OAuth2("b", "one", url.Values{}),
+		OAuth2("c", "one", url.Values{"test": []string{"test"}}),
+		OAuth2("d", "one", url.Values{"test": []string{"error"}}),
+		OAuth2("d", "one", url.Values{"test": []string{"test", "test"}}),
+		OAuth2("a", "two", nil),
+		OAuth2("b", "two", url.Values{}),
+		OAuth2("c", "two", url.Values{"test": []string{"test"}}),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
+}
+
+func TestRetryError_Is(t *testing.T) {
+	errs := []error{
+		Retry(io.EOF, "one"),
+		Retry(os.ErrNotExist, "one"),
+		Retry(io.EOF, "two"),
+		Retry(os.ErrNotExist, "two"),
+	}
+
+	for i := range errs {
+		for j := range errs {
+			if i == j {
+				require.ErrorIs(t, errs[i], errs[j])
+			} else {
+				require.NotErrorIs(t, errs[i], errs[j])
+				require.NotErrorIs(t, errs[j], errs[i])
+			}
+		}
+	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -134,6 +134,8 @@ func Test_Is(t *testing.T) {
 		},
 	}
 
+	require.ErrorIs(t, &CompareFailedError{}, CompareFailed(""))
+
 	// for each target error in the case check if it Is
 	for k := range cases {
 		t.Run(fmt.Sprintf("%T", k), func(t *testing.T) {
@@ -168,12 +170,15 @@ func TestNotFoundError_Is(t *testing.T) {
 	errs := []error{
 		NotFound("one"),
 		NotFound("two"),
+		Wrap(NotFound("three")),
 	}
 
 	for i := range errs {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -194,6 +199,8 @@ func TestAlreadyExistsError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -212,6 +219,8 @@ func TestBadParameterError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -230,6 +239,8 @@ func TestIsNotImplementedError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -248,6 +259,9 @@ func TestCompareFailedError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, errs[i], Wrap(errs[j]))
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -266,6 +280,8 @@ func TestAccessDeniedError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -286,6 +302,8 @@ func TestConnectionProblemError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -304,6 +322,8 @@ func TestLimitExceededError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -324,6 +344,8 @@ func TestTrustError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -348,6 +370,8 @@ func TestOauth2Error_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])
@@ -368,6 +392,8 @@ func TestRetryError_Is(t *testing.T) {
 		for j := range errs {
 			if i == j {
 				require.ErrorIs(t, errs[i], errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), errs[j])
+				require.ErrorIs(t, Wrap(errs[i]), Wrap(errs[j]))
 			} else {
 				require.NotErrorIs(t, errs[i], errs[j])
 				require.NotErrorIs(t, errs[j], errs[i])

--- a/trace.go
+++ b/trace.go
@@ -184,13 +184,13 @@ type Traces = internal.Traces
 type Trace = internal.Trace
 
 // MarshalJSON marshals this error as JSON-encoded payload
-func (r *TraceErr) MarshalJSON() ([]byte, error) {
-	if r == nil {
+func (e *TraceErr) MarshalJSON() ([]byte, error) {
+	if e == nil {
 		return nil, nil
 	}
 	type marshalableError TraceErr
-	err := marshalableError(*r)
-	err.Err = &RawTrace{Message: r.Err.Error()}
+	err := marshalableError(*e)
+	err.Err = &RawTrace{Message: e.Err.Error()}
 	return json.Marshal(err)
 }
 
@@ -355,7 +355,7 @@ type Error interface {
 	DebugReporter
 	UserMessager
 
-	// AddMessage adds formatted user-facing message
+	// AddUserMessage adds formatted user-facing message
 	// to the error, depends on the implementation,
 	// usually works as fmt.Sprintf(formatArg, rest...)
 	// but implementations can choose another way, e.g. treat


### PR DESCRIPTION
 Ensure that error contents match, not just that the types are the
 same in all `Is` implementations