### PR TITLE
Aggregate Error Is/As support

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -454,35 +454,26 @@ func (r aggregate) Error() string {
 	return output
 }
 
-// Unwrap implements `errors.Unwrap` in a somewhat unusual way to support
-// `errors.Is` and `errors.As`.
-//
-// One might expect Unwrap to return the error at the head of the slice, but,
-// instead we return the slice excluding the head. This, in combination with
-// `aggregate.Is` re-invoking `errors.Is` on the head of the slice essentially
-// allows for the original `errors.Is` to navigate the tree of error chains
-// created by `aggregate`.
-//
-// Reading the implementation for `errors.Is` and `errors.As` should provide
-// some further explanation.
-func (r aggregate) Unwrap() error {
-	if len(r) == 1 {
-		return nil
-	}
-
-	return r[1:]
-}
-
-// Is implements the errors.Is interface by re-invoking errors.Is on the error
-// at the head of the slice.
+// Is implements the `Is` interface, by iterating through each error in the
+// aggregate and invoking `errors.Is`.
 func (r aggregate) Is(t error) bool {
-	return errors.Is(r[0], t)
+	for _, err := range r {
+		if errors.Is(err, t) {
+			return true
+		}
+	}
+	return false
 }
 
-// As implements the errors.As interface by re-invoking errors.As on the error
-// at the head of the slice.
+// As implements the `As` interface, by iterating through each error in the
+// aggregate and invoking `errors.As`.
 func (r aggregate) As(t interface{}) bool {
-	return errors.As(r[0], t)
+	for _, err := range r {
+		if errors.As(err, t) {
+			return true
+		}
+	}
+	return false
 }
 
 // Errors obtains the list of errors this aggregate combines

--- a/trace.go
+++ b/trace.go
@@ -454,7 +454,7 @@ func (r aggregate) Error() string {
 	return output
 }
 
-// Unwrap implements errors.Unwrap in a somewhat unusual way to support
+// Unwrap implements `errors.Unwrap` in a somewhat unusual way to support
 // `errors.Is` and `errors.As`.
 //
 // One might expect Unwrap to return the error at the head of the slice, but,
@@ -462,6 +462,9 @@ func (r aggregate) Error() string {
 // `aggregate.Is` re-invoking `errors.Is` on the head of the slice essentially
 // allows for the original `errors.Is` to navigate the tree of error chains
 // created by `aggregate`.
+//
+// Reading the implementation for `errors.Is` and `errors.As` should provide
+// some further explanation.
 func (r aggregate) Unwrap() error {
 	if len(r) == 1 {
 		return nil
@@ -470,10 +473,16 @@ func (r aggregate) Unwrap() error {
 	return r[1:]
 }
 
-// Is implements the errors.Is interface, by re-invoking errors.Is on the
-// error at the head of the slice.
+// Is implements the errors.Is interface by re-invoking errors.Is on the error
+// at the head of the slice.
 func (r aggregate) Is(t error) bool {
 	return errors.Is(r[0], t)
+}
+
+// As implements the errors.As interface by re-invoking errors.As on the error
+// at the head of the slice.
+func (r aggregate) As(t interface{}) bool {
+	return errors.As(r[0], t)
 }
 
 // Errors obtains the list of errors this aggregate combines

--- a/trace_test.go
+++ b/trace_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -713,25 +714,11 @@ func TestStdlibCompat_Aggregate(t *testing.T) {
 
 	agg := Wrap(NewAggregate(Wrap(badParamErr), fooErr))
 
-	if !errors.Is(agg, badParamErr) {
-		t.Error("trace.Is(agg, badParamErr): got false, want true")
-	}
-	if !errors.Is(agg, fooErr) {
-		t.Error("trace.Is(agg, fooErr): got false, want true")
-	}
-	if errors.Is(agg, randomErr) {
-		t.Error("trace.Is(agg, randomErr): got true, want false")
-	}
+	require.ErrorIs(t, agg, badParamErr)
+	require.ErrorIs(t, agg, fooErr)
+	require.NotErrorIs(t, agg, randomErr)
 
 	var badParamErrTarget *BadParameterError
-	if !errors.As(agg, &badParamErrTarget) {
-		t.Error("trace.As(agg, badParamErrTarget): got true, want false")
-	} else {
-		if badParamErrTarget.Message != bpMsg {
-			t.Errorf(
-				"badParamErrTarget: got '%s', want '%s'",
-				badParamErrTarget.Message, bpMsg,
-			)
-		}
-	}
+	require.ErrorAs(t, agg, &badParamErrTarget)
+	require.Equal(t, bpMsg, badParamErrTarget.Message)
 }

--- a/trace_test.go
+++ b/trace_test.go
@@ -702,12 +702,13 @@ func TestStdlibCompat(t *testing.T) {
 	}
 }
 
-// TestStdLibCompat_Aggregate runs through a scenario which ensures a
-// that Aggregate behaves well with errors.Is/errors.As in cases with trace
+// TestStdLibCompat_Aggregate runs through a scenario which ensures that
+// Aggregate behaves well with errors.Is/errors.As in cases with trace
 // wrapped errors and stdlib errors
 func TestStdlibCompat_Aggregate(t *testing.T) {
 	randomErr := fmt.Errorf("random")
-	badParamErr := BadParameter("bad param")
+	bpMsg := "bad param"
+	badParamErr := BadParameter(bpMsg)
 	fooErr := fmt.Errorf("foo")
 
 	agg := Wrap(NewAggregate(Wrap(badParamErr), fooErr))
@@ -720,5 +721,17 @@ func TestStdlibCompat_Aggregate(t *testing.T) {
 	}
 	if errors.Is(agg, randomErr) {
 		t.Error("trace.Is(agg, randomErr): got true, want false")
+	}
+
+	var badParamErrTarget *BadParameterError
+	if !errors.As(agg, &badParamErrTarget) {
+		t.Error("trace.As(agg, badParamErrTarget): got true, want false")
+	} else {
+		if badParamErrTarget.Message != bpMsg {
+			t.Errorf(
+				"badParamErrTarget: got '%s', want '%s'",
+				badParamErrTarget.Message, bpMsg,
+			)
+		}
 	}
 }


### PR DESCRIPTION
Closes #76 

Implements support for Go's relatively new `errors.Is` and `errors.As` to `aggregate`. This ensures that the root causes of errors are not obscured when using `aggregate` as they currently are. See #76 for the specific use case I have in mind here.

Usage (in the form of a test ✨):

```go
func TestStdlibCompat_Aggregate(t *testing.T) {
	randomErr := fmt.Errorf("random")
	bpMsg := "bad param"
	badParamErr := BadParameter(bpMsg)
	fooErr := fmt.Errorf("foo")

	agg := Wrap(NewAggregate(Wrap(badParamErr), fooErr))

	require.ErrorIs(t, agg, badParamErr)
	require.ErrorIs(t, agg, fooErr)
	require.NotErrorIs(t, agg, randomErr)

	var badParamErrTarget *BadParameterError
	require.ErrorAs(t, agg, &badParamErrTarget)
	require.Equal(t, bpMsg, badParamErrTarget.Message)
}
```
