### PR TITLE
Do not discard invalid error payloads in `ReadError`

### DIFF
--- a/httplib.go
+++ b/httplib.go
@@ -129,7 +129,7 @@ func unmarshalError(err error, responseBody []byte) error {
 
 // errorOnInvalidJSON is used to construct a TraceErr with the
 // input error as Err and the responseBody as Messages.
-// This function is used when the responseBody is not a valid
+// This function is used when the responseBody is not valid
 // JSON or it contains an unexpected JSON.
 func errorOnInvalidJSON(err error, responseBody []byte) error {
 	return &TraceErr{

--- a/httplib.go
+++ b/httplib.go
@@ -107,12 +107,11 @@ func unmarshalError(err error, responseBody []byte) error {
 	}
 	var raw RawTrace
 	if err2 := json.Unmarshal(responseBody, &raw); err2 != nil {
-		return err
+		return errorOnInvalidJSON(err, responseBody)
 	}
 	if len(raw.Err) != 0 {
-		err2 := json.Unmarshal(raw.Err, err)
-		if err2 != nil {
-			return err
+		if err2 := json.Unmarshal(raw.Err, err); err2 != nil {
+			return errorOnInvalidJSON(err, responseBody)
 		}
 		return &TraceErr{
 			Traces:   raw.Traces,
@@ -122,6 +121,19 @@ func unmarshalError(err error, responseBody []byte) error {
 			Fields:   raw.Fields,
 		}
 	}
-	json.Unmarshal(responseBody, err)
+	if err2 := json.Unmarshal(responseBody, err); err2 != nil {
+		return errorOnInvalidJSON(err, responseBody)
+	}
 	return err
+}
+
+// errorOnInvalidJSON is used to construct a TraceErr with the
+// input error as Err and the responseBody as Messages.
+// This function is used when the responseBody is not a valid
+// JSON or it contains an unexpected JSON.
+func errorOnInvalidJSON(err error, responseBody []byte) error {
+	return &TraceErr{
+		Err:      err,
+		Messages: []string{string(responseBody)},
+	}
 }

--- a/httplib_test.go
+++ b/httplib_test.go
@@ -54,7 +54,7 @@ func TestReplyJSON(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
-			errCode := 400
+			const errCode = 400
 			replyJSON(recorder, errCode, tc.err)
 			require.JSONEq(t, expectedErrorResponse, recorder.Body.String())
 		})

--- a/httplib_test.go
+++ b/httplib_test.go
@@ -85,6 +85,34 @@ func TestUnmarshalError(t *testing.T) {
 			assertErr:     IsAccessDenied,
 			expectedMsg:   "ABC",
 		},
+		{
+			desc:          "unmarshal error without error JSON key",
+			inputErr:      &AccessDeniedError{},
+			inputResponse: `{"message": "ABC"}`,
+			assertErr:     IsAccessDenied,
+			expectedMsg:   "ABC",
+		},
+		{
+			desc:          "unmarshal invalid error",
+			inputErr:      &AccessDeniedError{},
+			inputResponse: `{"error": "message ABC"}`,
+			assertErr:     IsAccessDenied,
+			expectedMsg:   "{\"error\": \"message ABC\"}\n\taccess denied",
+		},
+		{
+			desc:          "unmarshal invalid error without error JSON key",
+			inputErr:      &AccessDeniedError{},
+			inputResponse: `["error message ABC"]`,
+			assertErr:     IsAccessDenied,
+			expectedMsg:   "[\"error message ABC\"]\n\taccess denied",
+		},
+		{
+			desc:          "unmarshal error with non-JSON body",
+			inputErr:      &AccessDeniedError{},
+			inputResponse: "error message ABC",
+			assertErr:     IsAccessDenied,
+			expectedMsg:   "error message ABC\n\taccess denied",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/17885.

This PR ensures that invalid error payloads are not discarded in case `ReadError` cannot parse them.

The first commit refactors the tests in `httplib_test.go` while the second commit does the actual change.