### PR TITLE
Prevent wrapping `io.EOF` in `trail.FromGRPC`

### DIFF
--- a/trail/trail.go
+++ b/trail/trail.go
@@ -18,21 +18,23 @@ limitations under the License.
 //
 // Example server that sends the GRPC error and attaches metadata:
 //
-//  func (s *server) Echo(ctx context.Context, message *gw.StringMessage) (*gw.StringMessage, error) {
-//      trace.SetDebug(true) // to tell trace to start attaching metadata
-//      // Send sends metadata via grpc header and converts error to GRPC compatible one
-//      return nil, trail.Send(ctx, trace.AccessDenied("missing authorization"))
-//  }
+//	func (s *server) Echo(ctx context.Context, message *gw.StringMessage) (*gw.StringMessage, error) {
+//	    trace.SetDebug(true) // to tell trace to start attaching metadata
+//	    // Send sends metadata via grpc header and converts error to GRPC compatible one
+//	    return nil, trail.Send(ctx, trace.AccessDenied("missing authorization"))
+//	}
 //
 // Example client reading error and trace debug info:
 //
-//  var header metadata.MD
-//	r, err := c.Echo(context.Background(), &gw.StringMessage{Value: message}, grpc.Header(&header))
-//	if err != nil {
-//      // FromGRPC reads error, converts it back to trace error and attaches debug metadata
-//      // like stack trace of the error origin back to the error
-//		err = trail.FromGRPC(err, header)
-///     // this line will log original trace of the error
+//	 var header metadata.MD
+//		r, err := c.Echo(context.Background(), &gw.StringMessage{Value: message}, grpc.Header(&header))
+//		if err != nil {
+//	     // FromGRPC reads error, converts it back to trace error and attaches debug metadata
+//	     // like stack trace of the error origin back to the error
+//			err = trail.FromGRPC(err, header)
+//
+// /     // this line will log original trace of the error
+//
 //		log.Errorf("error saying echo: %v", trace.DebugReport(err))
 //		return
 //	}
@@ -128,6 +130,11 @@ func FromGRPC(err error, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
+
+	if errors.Is(err, io.EOF) {
+		return err
+	}
+
 	code := grpc.Code(err)
 	message := grpc.ErrorDesc(err)
 	var e error

--- a/trail/trail_test.go
+++ b/trail/trail_test.go
@@ -50,7 +50,7 @@ func (s *TrailSuite) TestConversion() {
 		{
 			Error: io.EOF,
 			Predicate: func(err error) bool {
-				return errors.Is(err, io.EOF)
+				return err == io.EOF && errors.Is(err, io.EOF)
 			},
 		},
 		{
@@ -92,8 +92,12 @@ func (s *TrailSuite) TestConversion() {
 		s.Equal(tc.Error.Error(), grpc.ErrorDesc(grpcError), "test case %v", i+1)
 		out := FromGRPC(grpcError)
 		s.True(tc.Predicate(out), "test case %v", i+1)
-		s.Regexp(".*trail_test.go.*", line(trace.DebugReport(out)))
-		s.NotRegexp(".*trail.go.*", line(trace.DebugReport(out)))
+
+		var traceErr *trace.TraceErr
+		if errors.As(out, &traceErr) {
+			s.Regexp(".*trail_test.go.*", line(trace.DebugReport(out)))
+			s.NotRegexp(".*trail.go.*", line(trace.DebugReport(out)))
+		}
 	}
 }
 


### PR DESCRIPTION
Adds similar functionality that already exists in `trail.ToGRPC` to detect and return any `io.EOF` errors instead of wrapping them in a `trace.TraceErr` from `trail.FromGRPC`. This allows any consumers of errors to be able to check if the error is an `io.EOF` dircectly via a `if err == io.EOF` or via `errors.Is(err, io.EOF)`. Prior to this change only the latter would work since the error returned from `trail.FromGRPC` would've been `trace.TraceErr{Err: io.EOF}`.