### PR TITLE
feat!: Make "IsError" methods work with Go-wrapped errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -70,18 +70,18 @@ func (e *NotFoundError) Is(target error) bool {
 	return err.Message == e.Message
 }
 
-// IsNotFound returns whether this error is of NotFoundError type
+// IsNotFound returns true if `e` contains a [NotFoundError] in its chain.
 func IsNotFound(e error) bool {
-	type nf interface {
-		IsNotFoundError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		if _, ok := e.(nf); ok {
+	for e != nil {
+		if _, ok := e.(*NotFoundError); ok {
 			return true
 		}
-		return os.IsNotExist(e)
-	})
+		if os.IsNotExist(e) {
+			return true
+		}
+		e = errors.Unwrap(e)
+	}
+	return false
 }
 
 // AlreadyExists returns a new instance of AlreadyExists error
@@ -125,17 +125,11 @@ func (e *AlreadyExistsError) Is(target error) bool {
 	return err.Message == e.Message
 }
 
-// IsAlreadyExists returns whether this is error indicating that object
-// already exists
+// IsAlreadyExists returns true if `e` contains an [AlreadyExistsError] in its
+// chain.
 func IsAlreadyExists(e error) bool {
-	type ae interface {
-		IsAlreadyExistsError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(ae)
-		return ok
-	})
+	other := &AlreadyExistsError{}
+	return errors.As(e, &other)
 }
 
 // BadParameter returns a new instance of BadParameterError
@@ -176,16 +170,11 @@ func (b *BadParameterError) Is(target error) bool {
 	return err.Message == b.Message
 }
 
-// IsBadParameter returns whether this error is of BadParameterType
+// IsBadParameter returns true if `e` contains a [BadParameterError] in its
+// chain.
 func IsBadParameter(e error) bool {
-	type bp interface {
-		IsBadParameterError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(bp)
-		return ok
-	})
+	other := &BadParameterError{}
+	return errors.As(e, &other)
 }
 
 // NotImplemented returns a new instance of NotImplementedError
@@ -226,16 +215,11 @@ func (e *NotImplementedError) Is(target error) bool {
 	return err.Message == e.Message
 }
 
-// IsNotImplemented returns whether this error is of NotImplementedError type
+// IsNotImplemented returns true if `e` contains a [NotImplementedError] in its
+// chain.
 func IsNotImplemented(e error) bool {
-	type ni interface {
-		IsNotImplementedError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		err, ok := e.(ni)
-		return ok && err.IsNotImplementedError()
-	})
+	other := &NotImplementedError{}
+	return errors.As(e, &other)
 }
 
 // CompareFailed returns new instance of CompareFailedError
@@ -279,16 +263,11 @@ func (e *CompareFailedError) Is(target error) bool {
 	return err.Message == e.Message
 }
 
-// IsCompareFailed detects if this error is of CompareFailed type
+// IsCompareFailed returns true if `e` contains a [CompareFailedError] in its
+// chain.
 func IsCompareFailed(e error) bool {
-	type cf interface {
-		IsCompareFailedError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(cf)
-		return ok
-	})
+	other := &CompareFailedError{}
+	return errors.As(e, &other)
 }
 
 // AccessDenied returns new instance of AccessDeniedError
@@ -331,16 +310,11 @@ func (e *AccessDeniedError) Is(target error) bool {
 	return err.Message == e.Message
 }
 
-// IsAccessDenied detects if this error is of AccessDeniedError type
+// IsAccessDenied returns true if `e` contains an [AccessDeniedError] in its
+// chain.
 func IsAccessDenied(e error) bool {
-	type ad interface {
-		IsAccessDeniedError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(ad)
-		return ok
-	})
+	other := &AccessDeniedError{}
+	return errors.As(e, &other)
 }
 
 // ConvertSystemError converts system error to appropriate trace error
@@ -434,16 +408,11 @@ func (c *ConnectionProblemError) Is(target error) bool {
 	return err.Message == c.Message && err.Err == c.Err
 }
 
-// IsConnectionProblem returns whether this error is of ConnectionProblemError
+// IsConnectionProblem returns true if `e` contains a [ConnectionProblemError]
+// in its chain.
 func IsConnectionProblem(e error) bool {
-	type cp interface {
-		IsConnectionProblemError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(cp)
-		return ok
-	})
+	other := &ConnectionProblemError{}
+	return errors.As(e, &other)
 }
 
 // LimitExceeded returns whether new instance of LimitExceededError
@@ -483,16 +452,11 @@ func (e *LimitExceededError) Is(target error) bool {
 	return err.Message == e.Message
 }
 
-// IsLimitExceeded detects if this error is of LimitExceededError
+// IsLimitExceeded returns true if `e` contains a [LimitExceededError] in its
+// chain.
 func IsLimitExceeded(e error) bool {
-	type le interface {
-		IsLimitExceededError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(le)
-		return ok
-	})
+	other := &LimitExceededError{}
+	return errors.As(e, &other)
 }
 
 // Trust returns new instance of TrustError
@@ -546,16 +510,10 @@ func (t *TrustError) Is(target error) bool {
 	return err.Message == t.Message && err.Err == t.Err
 }
 
-// IsTrustError returns if this is a trust error
+// IsTrustError returns true if `e` contains a [TrustError] in its chain.
 func IsTrustError(e error) bool {
-	type te interface {
-		IsTrustError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(te)
-		return ok
-	})
+	other := &TrustError{}
+	return errors.As(e, &other)
 }
 
 // OAuth2 returns new instance of OAuth2Error
@@ -614,16 +572,10 @@ func (o *OAuth2Error) Is(target error) bool {
 	return true
 }
 
-// IsOAuth2 returns if this is a OAuth2-related error
+// IsOAuth2 returns true if `e` contains an [OAuth2Error] in its chain.
 func IsOAuth2(e error) bool {
-	type oe interface {
-		IsOAuth2Error() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(oe)
-		return ok
-	})
+	other := &OAuth2Error{}
+	return errors.As(e, &other)
 }
 
 // IsEOF returns true if the passed error is io.EOF.
@@ -682,24 +634,8 @@ func (c *RetryError) Is(target error) bool {
 	return err.Message == c.Message && err.Err == c.Err
 }
 
-// IsRetryError returns whether this error is of ConnectionProblemError
+// IsRetryError returns true if `e` contains a [RetryError] in its chain.
 func IsRetryError(e error) bool {
-	type re interface {
-		IsRetryError() bool
-	}
-
-	return recursiveIsError(e, func(e error) bool {
-		_, ok := e.(re)
-		return ok
-	})
-}
-
-func recursiveIsError(e error, fn func(e error) bool) bool {
-	if e == nil {
-		return false
-	}
-	if fn(e) {
-		return true
-	}
-	return recursiveIsError(errors.Unwrap(e), fn)
+	other := &RetryError{}
+	return errors.As(e, &other)
 }

--- a/errors.go
+++ b/errors.go
@@ -626,9 +626,10 @@ func IsOAuth2(e error) bool {
 	})
 }
 
-// IsEOF returns true if the passed error is io.EOF
+// IsEOF returns true if the passed error is io.EOF.
+// Deprecated: Use [errors.Is] instead.
 func IsEOF(e error) bool {
-	return Unwrap(e) == io.EOF
+	return errors.Is(Unwrap(e), io.EOF)
 }
 
 // Retry returns new instance of RetryError which indicates a transient error type

--- a/errors_test.go
+++ b/errors_test.go
@@ -404,77 +404,65 @@ func TestRetryError_Is(t *testing.T) {
 
 func TestGoErrorWrap_IsError_allTypes(t *testing.T) {
 	tests := []struct {
-		name          string
-		instance      error            // eg, BadParameter("foo")
-		instanceForAs interface{}      // eg, &BadParameterError{}
-		isError       func(error) bool // eg, IsBadParameter
+		name     string
+		instance error            // eg, BadParameter("foo")
+		isError  func(error) bool // eg, IsBadParameter
 	}{
 		{
-			name:          "BadParameter",
-			instance:      BadParameter("message"),
-			instanceForAs: &BadParameterError{},
-			isError:       IsBadParameter,
+			name:     "BadParameter",
+			instance: BadParameter("message"),
+			isError:  IsBadParameter,
 		},
 
 		{
-			name:          "NotFound",
-			instance:      NotFound("message"),
-			instanceForAs: &NotFoundError{},
-			isError:       IsNotFound,
+			name:     "NotFound",
+			instance: NotFound("message"),
+			isError:  IsNotFound,
 		},
 		{
-			name:          "AlreadyExists",
-			instance:      AlreadyExists("message"),
-			instanceForAs: &AlreadyExistsError{},
-			isError:       IsAlreadyExists,
+			name:     "AlreadyExists",
+			instance: AlreadyExists("message"),
+			isError:  IsAlreadyExists,
 		},
 		{
-			name:          "NotImplemented",
-			instance:      NotImplemented("message"),
-			instanceForAs: &NotImplementedError{},
-			isError:       IsNotImplemented,
+			name:     "NotImplemented",
+			instance: NotImplemented("message"),
+			isError:  IsNotImplemented,
 		},
 		{
-			name:          "CompareFailed",
-			instance:      CompareFailed("message"),
-			instanceForAs: &CompareFailedError{},
-			isError:       IsCompareFailed,
+			name:     "CompareFailed",
+			instance: CompareFailed("message"),
+			isError:  IsCompareFailed,
 		},
 		{
-			name:          "AccessDenied",
-			instance:      AccessDenied("message"),
-			instanceForAs: &AccessDeniedError{},
-			isError:       IsAccessDenied,
+			name:     "AccessDenied",
+			instance: AccessDenied("message"),
+			isError:  IsAccessDenied,
 		},
 		{
-			name:          "ConnectionProblem",
-			instance:      ConnectionProblem(errors.New("underlying error"), "message"),
-			instanceForAs: &ConnectionProblemError{},
-			isError:       IsConnectionProblem,
+			name:     "ConnectionProblem",
+			instance: ConnectionProblem(errors.New("underlying error"), "message"),
+			isError:  IsConnectionProblem,
 		},
 		{
-			name:          "LimitExceeded",
-			instance:      LimitExceeded("message"),
-			instanceForAs: &LimitExceededError{},
-			isError:       IsLimitExceeded,
+			name:     "LimitExceeded",
+			instance: LimitExceeded("message"),
+			isError:  IsLimitExceeded,
 		},
 		{
-			name:          "TrustError",
-			instance:      Trust(errors.New("underlying error"), "message"),
-			instanceForAs: &TrustError{},
-			isError:       IsTrustError,
+			name:     "TrustError",
+			instance: Trust(errors.New("underlying error"), "message"),
+			isError:  IsTrustError,
 		},
 		{
-			name:          "OAuth2",
-			instance:      OAuth2("code", "message", nil /* query */),
-			instanceForAs: &OAuth2Error{},
-			isError:       IsOAuth2,
+			name:     "OAuth2",
+			instance: OAuth2("code", "message", nil /* query */),
+			isError:  IsOAuth2,
 		},
 		{
-			name:          "RetryError",
-			instance:      Retry(errors.New("underyling error"), "message"),
-			instanceForAs: &RetryError{},
-			isError:       IsRetryError,
+			name:     "RetryError",
+			instance: Retry(errors.New("underyling error"), "message"),
+			isError:  IsRetryError,
 		},
 	}
 	for _, test := range tests {
@@ -483,16 +471,18 @@ func TestGoErrorWrap_IsError_allTypes(t *testing.T) {
 			err2 := Wrap(err1)
 			err3 := fmt.Errorf("go wrap: %w", err1)
 			err4 := fmt.Errorf("go plus trace wrap: %w", err2)
+			errUnrelated := fmt.Errorf("go wrap: %w", Wrap(errors.New("unrelated")))
 
+			// Verify positive matches.
 			for _, testErr := range []error{err1, err2, err3, err4} {
 				if !test.isError(testErr) {
 					t.Errorf("Is%v failed, err=%#v", test.name, testErr)
 				}
+			}
 
-				otherErr := test.instanceForAs
-				if !errors.As(testErr, &otherErr) {
-					t.Errorf("errors.As failed, err=%#v", testErr)
-				}
+			// Verify that an unrelated error won't match.
+			if test.isError(errUnrelated) {
+				t.Errorf("Is%v returned true for an unrelated error, err=%#v", test.name, errUnrelated)
 			}
 		})
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -229,7 +229,7 @@ func TestBadParameterError_Is(t *testing.T) {
 	}
 }
 
-func TestIsNotImplementedError_Is(t *testing.T) {
+func TestNotImplementedError_Is(t *testing.T) {
 	errs := []error{
 		NotImplemented("one"),
 		NotImplemented("two"),

--- a/internal/frames.go
+++ b/internal/frames.go
@@ -85,11 +85,6 @@ func frameToTrace(frame runtime.Frame) Trace {
 	}
 }
 
-// SetTraces adds new traces to the list
-func (s Traces) SetTraces(traces ...Trace) {
-	s = append(s, traces...)
-}
-
 // Func returns first function in trace list
 func (s Traces) Func() string {
 	if len(s) == 0 {

--- a/log.go
+++ b/log.go
@@ -168,14 +168,14 @@ type JSONFormatter struct {
 func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 	if cursor := findFrame(); cursor != nil {
 		t := internal.GetTracesFromCursor(*cursor)
-		new := e.WithFields(log.Fields{
+		newEntry := e.WithFields(log.Fields{
 			FileField:     t.Loc(),
 			FunctionField: t.FuncName(),
 		})
-		new.Time = e.Time
-		new.Level = e.Level
-		new.Message = e.Message
-		e = new
+		newEntry.Time = e.Time
+		newEntry.Level = e.Level
+		newEntry.Message = e.Message
+		e = newEntry
 	}
 	return j.JSONFormatter.Format(e)
 }

--- a/trace.go
+++ b/trace.go
@@ -66,7 +66,15 @@ func Wrap(err error, args ...interface{}) Error {
 	return trace
 }
 
-// Unwrap returns the original error the given error wraps
+// Unwrap returns the original error the given error wraps. It is equivalent to
+// removing all trace layers until the original error is exposed.
+//
+// Unwrap works mainly on trace errors, so it won't unwrap errors wrapped via
+// Go's `%w`.
+//
+// Prefer using higher-level comparison methods, such as the various "IsError"
+// functions in this package or [errors.Is] and [errors.As]. If you want a
+// general error-unwrapping mechanism, consider using [errors.Unwrap] instead.
 func Unwrap(err error) error {
 	if err, ok := err.(ErrorWrapper); ok {
 		return err.OrigError()


### PR DESCRIPTION
"IsError" methods, like "IsBadParameter" or "IsNotFound", fail to identify the corresponding errors if Go wrapping is used in the chain. This PR fixes that, allowing `trace.Wrap` and `fmt.Errorf` to coexist gracefully.

Comparisons are now based on `errors.As` (or equivalent logic), not the previous interface-casting mechanisms.

I've also taken the opportunity to address some other issues within the codebase.