### PR TITLE
Manually unwrap on `trail.ToGRPC`

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,11 +26,14 @@ import (
 	"os"
 )
 
+// traceDepth is the depth to be used by error constructors.
+const traceDepth = 2
+
 // NotFound returns new instance of not found error
 func NotFound(message string, args ...interface{}) Error {
 	return newTrace(&NotFoundError{
 		Message: fmt.Sprintf(message, args...),
-	}, 2)
+	}, traceDepth)
 }
 
 // NotFoundError indicates that object has not been found
@@ -88,7 +91,7 @@ func IsNotFound(e error) bool {
 func AlreadyExists(message string, args ...interface{}) Error {
 	return newTrace(&AlreadyExistsError{
 		Message: fmt.Sprintf(message, args...),
-	}, 2)
+	}, traceDepth)
 }
 
 // AlreadyExistsError indicates that there's a duplicate object that already
@@ -136,7 +139,7 @@ func IsAlreadyExists(e error) bool {
 func BadParameter(message string, args ...interface{}) Error {
 	return newTrace(&BadParameterError{
 		Message: fmt.Sprintf(message, args...),
-	}, 2)
+	}, traceDepth)
 }
 
 // BadParameterError indicates that something is wrong with passed
@@ -181,7 +184,7 @@ func IsBadParameter(e error) bool {
 func NotImplemented(message string, args ...interface{}) Error {
 	return newTrace(&NotImplementedError{
 		Message: fmt.Sprintf(message, args...),
-	}, 2)
+	}, traceDepth)
 }
 
 // NotImplementedError defines an error condition to describe the result
@@ -226,7 +229,7 @@ func IsNotImplemented(e error) bool {
 func CompareFailed(message string, args ...interface{}) Error {
 	return newTrace(&CompareFailedError{
 		Message: fmt.Sprintf(message, args...),
-	}, 2)
+	}, traceDepth)
 }
 
 // CompareFailedError indicates a failed comparison (e.g. bad password or hash)
@@ -274,7 +277,7 @@ func IsCompareFailed(e error) bool {
 func AccessDenied(message string, args ...interface{}) Error {
 	return newTrace(&AccessDeniedError{
 		Message: fmt.Sprintf(message, args...),
-	}, 2)
+	}, traceDepth)
 }
 
 // AccessDeniedError indicates denied access
@@ -325,35 +328,35 @@ func ConvertSystemError(err error) error {
 	if os.IsExist(innerError) {
 		return newTrace(&AlreadyExistsError{
 			Message: innerError.Error(),
-		}, 2)
+		}, traceDepth)
 	}
 	if os.IsNotExist(innerError) {
 		return newTrace(&NotFoundError{
 			Message: innerError.Error(),
-		}, 2)
+		}, traceDepth)
 	}
 	if os.IsPermission(innerError) {
 		return newTrace(&AccessDeniedError{
 			Message: innerError.Error(),
-		}, 2)
+		}, traceDepth)
 	}
 	switch realErr := innerError.(type) {
 	case *net.OpError:
 		return newTrace(&ConnectionProblemError{
 			Err: realErr,
-		}, 2)
+		}, traceDepth)
 	case *os.PathError:
 		message := fmt.Sprintf("failed to execute command %v error:  %v", realErr.Path, realErr.Err)
 		return newTrace(&AccessDeniedError{
 			Message: message,
-		}, 2)
+		}, traceDepth)
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
-		return newTrace(&TrustError{Err: innerError}, 2)
+		return newTrace(&TrustError{Err: innerError}, traceDepth)
 	}
 	if _, ok := innerError.(net.Error); ok {
 		return newTrace(&ConnectionProblemError{
 			Err: innerError,
-		}, 2)
+		}, traceDepth)
 	}
 	return err
 }
@@ -363,7 +366,7 @@ func ConnectionProblem(err error, message string, args ...interface{}) Error {
 	return newTrace(&ConnectionProblemError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, 2)
+	}, traceDepth)
 }
 
 // ConnectionProblemError indicates a network related problem
@@ -419,7 +422,7 @@ func IsConnectionProblem(e error) bool {
 func LimitExceeded(message string, args ...interface{}) Error {
 	return newTrace(&LimitExceededError{
 		Message: fmt.Sprintf(message, args...),
-	}, 2)
+	}, traceDepth)
 }
 
 // LimitExceededError indicates rate limit or connection limit problem
@@ -464,7 +467,7 @@ func Trust(err error, message string, args ...interface{}) Error {
 	return newTrace(&TrustError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, 2)
+	}, traceDepth)
 }
 
 // TrustError indicates trust-related validation error (e.g. untrusted cert)
@@ -522,7 +525,7 @@ func OAuth2(code, message string, query url.Values) Error {
 		Code:    code,
 		Message: message,
 		Query:   query,
-	}, 2)
+	}, traceDepth)
 }
 
 // OAuth2Error defined an error used in OpenID Connect Flow (OIDC)
@@ -589,7 +592,7 @@ func Retry(err error, message string, args ...interface{}) Error {
 	return newTrace(&RetryError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, 2)
+	}, traceDepth)
 }
 
 // RetryError indicates a transient error type

--- a/errors_test.go
+++ b/errors_test.go
@@ -461,7 +461,7 @@ func TestGoErrorWrap_IsError_allTypes(t *testing.T) {
 		},
 		{
 			name:     "RetryError",
-			instance: Retry(errors.New("underyling error"), "message"),
+			instance: Retry(errors.New("underlying error"), "message"),
 			isError:  IsRetryError,
 		},
 	}

--- a/trail/trail_test.go
+++ b/trail/trail_test.go
@@ -24,24 +24,16 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
-func TestTrail(t *testing.T) {
-	suite.Run(t, new(TrailSuite))
-}
-
-type TrailSuite struct {
-	suite.Suite
-}
-
 // TestConversion makes sure we convert all trace supported errors
 // to and back from GRPC codes
-func (s *TrailSuite) TestConversion() {
+func TestConversion(t *testing.T) {
 	testCases := []struct {
 		Error     error
 		Message   string
@@ -89,34 +81,34 @@ func (s *TrailSuite) TestConversion() {
 
 	for i, tc := range testCases {
 		grpcError := ToGRPC(tc.Error)
-		s.Equal(tc.Error.Error(), status.Convert(grpcError).Message(), "test case %v", i+1)
+		assert.Equal(t, tc.Error.Error(), status.Convert(grpcError).Message(), "test case %v", i+1)
 		out := FromGRPC(grpcError)
-		s.True(tc.Predicate(out), "test case %v", i+1)
-		s.Regexp(".*trail_test.go.*", line(trace.DebugReport(out)))
-		s.NotRegexp(".*trail.go.*", line(trace.DebugReport(out)))
+		assert.True(t, tc.Predicate(out), "test case %v", i+1)
+		assert.Regexp(t, ".*trail_test.go.*", line(trace.DebugReport(out)))
+		assert.NotRegexp(t, ".*trail.go.*", line(trace.DebugReport(out)))
 	}
 }
 
 // TestNil makes sure conversions of nil to and from GRPC are no-op
-func (s *TrailSuite) TestNil() {
+func TestNil(t *testing.T) {
 	out := FromGRPC(ToGRPC(nil))
-	s.Nil(out)
+	assert.Nil(t, out)
 }
 
 // TestFromEOF makes sure that non-grpc error such as io.EOF is preserved well.
-func (s *TrailSuite) TestFromEOF() {
+func TestFromEOF(t *testing.T) {
 	out := FromGRPC(trace.Wrap(io.EOF))
-	s.True(trace.IsEOF(out))
+	assert.True(t, trace.IsEOF(out))
 }
 
 // TestTraces makes sure we pass traces via metadata and can decode it back
-func (s *TrailSuite) TestTraces() {
+func TestTraces(t *testing.T) {
 	err := trace.BadParameter("param")
 	meta := metadata.New(nil)
 	SetDebugInfo(err, meta)
 	err2 := FromGRPC(ToGRPC(err), meta)
-	s.Regexp(".*trail_test.go.*", line(trace.DebugReport(err)))
-	s.Regexp(".*trail_test.go.*", line(trace.DebugReport(err2)))
+	assert.Regexp(t, ".*trail_test.go.*", line(trace.DebugReport(err)))
+	assert.Regexp(t, ".*trail_test.go.*", line(trace.DebugReport(err2)))
 }
 
 func line(s string) string {

--- a/udphook_test.go
+++ b/udphook_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package trace
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
@@ -35,7 +35,7 @@ func TestHooks(t *testing.T) {
 
 func (s *HooksSuite) TestSafeForConcurrentAccess() {
 	logger := log.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 	entry := logger.WithFields(log.Fields{"foo": "bar"})
 	logger.Hooks.Add(&UDPHook{Clock: clockwork.NewFakeClock()})
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
Manually unwrap and type-switch so we avoid the many inner loops of repeated "IsError" calls.

I've snuck in a few other minor tweaks again. :)