### PR TITLE
feat!: Make IsAggregate work with Go-wrapped errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,14 +26,11 @@ import (
 	"os"
 )
 
-// traceDepth is the depth to be used by error constructors.
-const traceDepth = 2
-
 // NotFound returns new instance of not found error
 func NotFound(message string, args ...interface{}) Error {
 	return newTrace(&NotFoundError{
 		Message: fmt.Sprintf(message, args...),
-	}, traceDepth)
+	})
 }
 
 // NotFoundError indicates that object has not been found
@@ -91,7 +88,7 @@ func IsNotFound(e error) bool {
 func AlreadyExists(message string, args ...interface{}) Error {
 	return newTrace(&AlreadyExistsError{
 		Message: fmt.Sprintf(message, args...),
-	}, traceDepth)
+	})
 }
 
 // AlreadyExistsError indicates that there's a duplicate object that already
@@ -139,7 +136,7 @@ func IsAlreadyExists(e error) bool {
 func BadParameter(message string, args ...interface{}) Error {
 	return newTrace(&BadParameterError{
 		Message: fmt.Sprintf(message, args...),
-	}, traceDepth)
+	})
 }
 
 // BadParameterError indicates that something is wrong with passed
@@ -184,7 +181,7 @@ func IsBadParameter(e error) bool {
 func NotImplemented(message string, args ...interface{}) Error {
 	return newTrace(&NotImplementedError{
 		Message: fmt.Sprintf(message, args...),
-	}, traceDepth)
+	})
 }
 
 // NotImplementedError defines an error condition to describe the result
@@ -229,7 +226,7 @@ func IsNotImplemented(e error) bool {
 func CompareFailed(message string, args ...interface{}) Error {
 	return newTrace(&CompareFailedError{
 		Message: fmt.Sprintf(message, args...),
-	}, traceDepth)
+	})
 }
 
 // CompareFailedError indicates a failed comparison (e.g. bad password or hash)
@@ -277,7 +274,7 @@ func IsCompareFailed(e error) bool {
 func AccessDenied(message string, args ...interface{}) Error {
 	return newTrace(&AccessDeniedError{
 		Message: fmt.Sprintf(message, args...),
-	}, traceDepth)
+	})
 }
 
 // AccessDeniedError indicates denied access
@@ -328,35 +325,35 @@ func ConvertSystemError(err error) error {
 	if os.IsExist(innerError) {
 		return newTrace(&AlreadyExistsError{
 			Message: innerError.Error(),
-		}, traceDepth)
+		})
 	}
 	if os.IsNotExist(innerError) {
 		return newTrace(&NotFoundError{
 			Message: innerError.Error(),
-		}, traceDepth)
+		})
 	}
 	if os.IsPermission(innerError) {
 		return newTrace(&AccessDeniedError{
 			Message: innerError.Error(),
-		}, traceDepth)
+		})
 	}
 	switch realErr := innerError.(type) {
 	case *net.OpError:
 		return newTrace(&ConnectionProblemError{
 			Err: realErr,
-		}, traceDepth)
+		})
 	case *os.PathError:
 		message := fmt.Sprintf("failed to execute command %v error:  %v", realErr.Path, realErr.Err)
 		return newTrace(&AccessDeniedError{
 			Message: message,
-		}, traceDepth)
+		})
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
-		return newTrace(&TrustError{Err: innerError}, traceDepth)
+		return newTrace(&TrustError{Err: innerError})
 	}
 	if _, ok := innerError.(net.Error); ok {
 		return newTrace(&ConnectionProblemError{
 			Err: innerError,
-		}, traceDepth)
+		})
 	}
 	return err
 }
@@ -366,7 +363,7 @@ func ConnectionProblem(err error, message string, args ...interface{}) Error {
 	return newTrace(&ConnectionProblemError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, traceDepth)
+	})
 }
 
 // ConnectionProblemError indicates a network related problem
@@ -422,7 +419,7 @@ func IsConnectionProblem(e error) bool {
 func LimitExceeded(message string, args ...interface{}) Error {
 	return newTrace(&LimitExceededError{
 		Message: fmt.Sprintf(message, args...),
-	}, traceDepth)
+	})
 }
 
 // LimitExceededError indicates rate limit or connection limit problem
@@ -467,7 +464,7 @@ func Trust(err error, message string, args ...interface{}) Error {
 	return newTrace(&TrustError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, traceDepth)
+	})
 }
 
 // TrustError indicates trust-related validation error (e.g. untrusted cert)
@@ -525,7 +522,7 @@ func OAuth2(code, message string, query url.Values) Error {
 		Code:    code,
 		Message: message,
 		Query:   query,
-	}, traceDepth)
+	})
 }
 
 // OAuth2Error defined an error used in OpenID Connect Flow (OIDC)
@@ -592,7 +589,7 @@ func Retry(err error, message string, args ...interface{}) Error {
 	return newTrace(&RetryError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, traceDepth)
+	})
 }
 
 // RetryError indicates a transient error type

--- a/errors.go
+++ b/errors.go
@@ -73,12 +73,22 @@ func (e *NotFoundError) Is(target error) bool {
 // IsNotFound returns true if `e` contains a [NotFoundError] in its chain.
 func IsNotFound(e error) bool {
 	for e != nil {
-		if _, ok := e.(*NotFoundError); ok {
+		switch e := e.(type) {
+		case *NotFoundError:
 			return true
+
+		// Aggregates and other errors.
+		case interface{ As(interface{}) bool }:
+			nfe := &NotFoundError{}
+			if e.As(&nfe) {
+				return true
+			}
 		}
+
 		if os.IsNotExist(e) {
 			return true
 		}
+
 		e = errors.Unwrap(e)
 	}
 	return false

--- a/errors_test.go
+++ b/errors_test.go
@@ -471,10 +471,11 @@ func TestGoErrorWrap_IsError_allTypes(t *testing.T) {
 			err2 := Wrap(err1)
 			err3 := fmt.Errorf("go wrap: %w", err1)
 			err4 := fmt.Errorf("go plus trace wrap: %w", err2)
+			err5 := NewAggregate(errors.New("some other error"), err4)
 			errUnrelated := fmt.Errorf("go wrap: %w", Wrap(errors.New("unrelated")))
 
 			// Verify positive matches.
-			for _, testErr := range []error{err1, err2, err3, err4} {
+			for _, testErr := range []error{err1, err2, err3, err4, err5} {
 				if !test.isError(testErr) {
 					t.Errorf("Is%v failed, err=%#v", test.name, testErr)
 				}

--- a/trace.go
+++ b/trace.go
@@ -475,14 +475,14 @@ type aggregate []error
 
 // Error implements the error interface
 func (r aggregate) Error() string {
-	if len(r) == 0 {
-		return ""
+	buf := &strings.Builder{}
+	for i, e := range r {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(e.Error())
 	}
-	output := r[0].Error()
-	for i := 1; i < len(r); i++ {
-		output = fmt.Sprintf("%v, %v", output, r[i])
-	}
-	return output
+	return buf.String()
 }
 
 // Is implements the `Is` interface, by iterating through each error in the

--- a/trace.go
+++ b/trace.go
@@ -427,8 +427,7 @@ func WithFields(err Error, fields map[string]interface{}) *TraceErr {
 // NewAggregate creates a new aggregate instance from the specified
 // list of errors
 func NewAggregate(errs ...error) error {
-	// filter out possible nil values
-	var nonNils []error
+	nonNils := make([]error, 0, len(errs))
 	for _, err := range errs {
 		if err != nil {
 			nonNils = append(nonNils, err)

--- a/trace.go
+++ b/trace.go
@@ -513,10 +513,11 @@ func (r aggregate) Errors() []error {
 	return []error(r)
 }
 
-// IsAggregate returns whether this error of Aggregate error type
+// IsAggregate returns true if `err` contains an [Aggregate] error in its
+// chain.
 func IsAggregate(err error) bool {
-	_, ok := Unwrap(err).(Aggregate)
-	return ok
+	var other Aggregate
+	return errors.As(err, &other)
 }
 
 // wrapProxy wraps the specified error as a new error trace

--- a/trace.go
+++ b/trace.go
@@ -202,6 +202,8 @@ func Fatalf(format string, args ...interface{}) error {
 }
 
 func newTrace(err error) *TraceErr {
+	// newTrace does not call newTraceWithDepth so the depth value is consistent
+	// between both methods.
 	const depth = 2
 	traces := internal.CaptureTraces(depth)
 	return &TraceErr{Err: err, Traces: traces}

--- a/trace.go
+++ b/trace.go
@@ -509,7 +509,9 @@ func (r aggregate) As(t interface{}) bool {
 
 // Errors obtains the list of errors this aggregate combines
 func (r aggregate) Errors() []error {
-	return []error(r)
+	cp := make([]error, len(r))
+	copy(cp, r)
+	return cp
 }
 
 // IsAggregate returns true if `err` contains an [Aggregate] error in its

--- a/trace_test.go
+++ b/trace_test.go
@@ -797,3 +797,20 @@ func TestIsAggregate(t *testing.T) {
 		})
 	}
 }
+
+func TestAggregate_IsError(t *testing.T) {
+	err1 := BadParameter("bad")
+	err2 := NotFound("not found")
+	err3 := errors.New("some other error")
+	errAggregate := NewAggregate(err1, err2, err3)
+	errUnrelated := errors.New("unrelated error")
+
+	assert.True(t, IsBadParameter(errAggregate), "IsBadParameter aggregate mismatch")
+	assert.True(t, IsNotFound(errAggregate), "IsNotFound aggregate mismatch")
+	assert.False(t, IsConnectionProblem(errAggregate), "IsConnectionProblem aggregate mismatch")
+
+	assert.ErrorIs(t, errAggregate, err1)
+	assert.ErrorIs(t, errAggregate, err2)
+	assert.ErrorIs(t, errAggregate, err3)
+	assert.NotErrorIs(t, errAggregate, errUnrelated)
+}

--- a/trace_test.go
+++ b/trace_test.go
@@ -731,24 +731,27 @@ func TestStdlibCompat(t *testing.T) {
 	}
 }
 
-// TestStdLibCompat_Aggregate runs through a scenario which ensures that
-// Aggregate behaves well with errors.Is/errors.As in cases with trace
-// wrapped errors and stdlib errors
-func TestStdlibCompat_Aggregate(t *testing.T) {
-	randomErr := fmt.Errorf("random")
+// TestAggregate_StdLibCompat runs through a scenario which ensures that
+// Aggregate behaves well with errors.Is/errors.As in cases with trace wrapped
+// errors and stdlib errors
+func TestAggregate_StdlibCompat(t *testing.T) {
+	randomErr := errors.New("random")
 	bpMsg := "bad param"
-	badParamErr := BadParameter(bpMsg)
-	fooErr := fmt.Errorf("foo")
+	bpErr := BadParameter(bpMsg)
+	fooErr := errors.New("foo")
 
-	agg := Wrap(NewAggregate(Wrap(badParamErr), fooErr))
+	agg := Wrap(NewAggregate(Wrap(bpErr), fooErr))
 
-	require.ErrorIs(t, agg, badParamErr)
-	require.ErrorIs(t, agg, fooErr)
-	require.NotErrorIs(t, agg, randomErr)
+	assert.ErrorIs(t, agg, bpErr)
+	assert.ErrorIs(t, agg, fooErr)
+	assert.NotErrorIs(t, agg, randomErr)
 
 	var badParamErrTarget *BadParameterError
-	require.ErrorAs(t, agg, &badParamErrTarget)
-	require.Equal(t, bpMsg, badParamErrTarget.Message)
+	assert.ErrorAs(t, agg, &badParamErrTarget)
+	assert.Equal(t, bpMsg, badParamErrTarget.Message, "BadParameter message mismatch")
+
+	var notFoundTarget *NotFoundError
+	assert.False(t, errors.As(agg, &notFoundTarget), "Aggregate does not contain a NotFoundError")
 }
 
 func TestIsAggregate(t *testing.T) {


### PR DESCRIPTION
Originally missed from #95.

I've done a few other tweaks to existing code, but only is IsAggregate and Errors are visibly-changed (other methods may be slightly more performant).

I've also added "IsError" tests for aggregated errors and fixed an issue where our custom IsNotFound logic didn't call `As(any) bool`.