### PR TITLE
fix: Handle aggregates correctly in `trail.ToGRPC`

### DIFF
--- a/internal/traverse.go
+++ b/internal/traverse.go
@@ -1,0 +1,28 @@
+package internal
+
+// TraverseErr traverses the err error chain until fn returns true.
+// Traversal stops on nil errors, fn(nil) is never called.
+// Returns true if fn matched, false otherwise.
+func TraverseErr(err error, fn func(error) (ok bool)) (ok bool) {
+	if err == nil {
+		return false
+	}
+
+	if fn(err) {
+		return true
+	}
+
+	switch err := err.(type) {
+	case interface{ Unwrap() error }:
+		return TraverseErr(err.Unwrap(), fn)
+
+	case interface{ Unwrap() []error }:
+		for _, err2 := range err.Unwrap() {
+			if TraverseErr(err2, fn) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/trace.go
+++ b/trace.go
@@ -493,33 +493,16 @@ func (r aggregate) Error() string {
 	return buf.String()
 }
 
-// Is implements the `Is` interface, by iterating through each error in the
-// aggregate and invoking `errors.Is`.
-func (r aggregate) Is(t error) bool {
-	for _, err := range r {
-		if errors.Is(err, t) {
-			return true
-		}
-	}
-	return false
-}
-
-// As implements the `As` interface, by iterating through each error in the
-// aggregate and invoking `errors.As`.
-func (r aggregate) As(t interface{}) bool {
-	for _, err := range r {
-		if errors.As(err, t) {
-			return true
-		}
-	}
-	return false
-}
-
 // Errors obtains the list of errors this aggregate combines
 func (r aggregate) Errors() []error {
 	cp := make([]error, len(r))
 	copy(cp, r)
 	return cp
+}
+
+// Unwrap returns the underlying aggregated errors.
+func (r aggregate) Unwrap() []error {
+	return r.Errors()
 }
 
 // IsAggregate returns true if `err` contains an [Aggregate] error in its

--- a/trace.go
+++ b/trace.go
@@ -493,6 +493,30 @@ func (r aggregate) Error() string {
 	return buf.String()
 }
 
+// Is implements the `Is` interface, by iterating through each error in the
+// aggregate and invoking `errors.Is`.
+// Required for Go versions < 1.20 (newer releases support "Unwrap() []error").
+func (r aggregate) Is(t error) bool {
+	for _, err := range r {
+		if errors.Is(err, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// As implements the `As` interface, by iterating through each error in the
+// aggregate and invoking `errors.As`.
+// Required for Go versions < 1.20 (newer releases support "Unwrap() []error").
+func (r aggregate) As(t interface{}) bool {
+	for _, err := range r {
+		if errors.As(err, t) {
+			return true
+		}
+	}
+	return false
+}
+
 // Errors obtains the list of errors this aggregate combines
 func (r aggregate) Errors() []error {
 	cp := make([]error, len(r))

--- a/trace_test.go
+++ b/trace_test.go
@@ -747,11 +747,11 @@ func TestAggregate_StdlibCompat(t *testing.T) {
 	assert.NotErrorIs(t, agg, randomErr)
 
 	var badParamErrTarget *BadParameterError
-	assert.ErrorAs(t, agg, &badParamErrTarget)
+	require.ErrorAs(t, agg, &badParamErrTarget)
 	assert.Equal(t, bpMsg, badParamErrTarget.Message, "BadParameter message mismatch")
 
 	var notFoundTarget *NotFoundError
-	assert.False(t, errors.As(agg, &notFoundTarget), "Aggregate does not contain a NotFoundError")
+	require.False(t, errors.As(agg, &notFoundTarget), "Aggregate does not contain a NotFoundError")
 }
 
 func TestIsAggregate(t *testing.T) {


### PR DESCRIPTION
Handle aggregates (and `os.IsNotExist`) in conversion to status errors.

Aggregates now implement `Unwrap() []error`, the same method provided by `errors.Join`. This makes it unnecessary to directly implement As() and Is(), since the corresponding errors methods can use the sliced-Unwrap to traverse the errors.

Both trail and IsNotFound now check for Unwrap() []error in their loops, making them correctly support aggregates (and std-joined errors).