### PR TITLE
fix: Change DefaultComponentPadding to handle kubernetes

### DIFF
--- a/log.go
+++ b/log.go
@@ -50,7 +50,7 @@ const (
 	// ComponentFields is a fields component
 	ComponentFields = "trace.fields"
 	// DefaultComponentPadding is a default padding for component field
-	DefaultComponentPadding = 11
+	DefaultComponentPadding = 12
 	// DefaultLevelPadding is a default padding for level field
 	DefaultLevelPadding = 4
 )


### PR DESCRIPTION
The current `DefaultComponentPadding` value is set to 11, which represents the Kubernetes component log from the teleport-agent as `[KUBERNETE]`. To properly represent Kubernetes, set `DefaultComponentPadding` to 12.

For example, a teleport-agent with the current value will display the Kubernetes component log as follows:

```
2023-10-05T11:18:07Z INFO [KUBERNETE] Round trip: GET https://1.2.3.4:443/apis/metrics.k8s.io/v1beta1?timeout=32s, code: 200, duration: 7.019246ms tls:version: 304, tls:resume:false, tls:csuite:1301, tls:server:kube-teleport-proxy-alpn.teleport.cluster.local pid:7.1 reverseproxy/reverse_proxy.go:236
```

As you can see above, the logging format shows the Kubernetes component name as `KUBERNETE`.