### PR TITLE
WrapWithMessage returns nil if error is nil.

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -174,6 +174,9 @@ func GetFields(err error) map[string]interface{} {
 
 // WrapWithMessage wraps the original error into Error and adds user message if any
 func WrapWithMessage(err error, message interface{}, args ...interface{}) Error {
+	if err == nil {
+		return nil
+	}
 	var trace Error
 	if traceErr, ok := err.(Error); ok {
 		trace = traceErr

--- a/trace_test.go
+++ b/trace_test.go
@@ -80,6 +80,8 @@ func TestWrapWithMessage(t *testing.T) {
 	assert.Equal(t, "user message\tdescription", line(UserMessage(err)))
 	assert.Regexp(t, ".*trace_test.go.*", line(DebugReport(err)))
 	assert.NotRegexp(t, ".*trace.go.*", line(DebugReport(err)))
+	err = WrapWithMessage(nil, "user message")
+	assert.NoError(t, err)
 }
 
 func TestUserMessageWithFields(t *testing.T) {


### PR DESCRIPTION
WrapWithMessage now returns a nil error if the provided error is nil.

Note: It's unclear if this breaks anything in Teleport, so we should think this through before merging.