### PR TITLE
Add CompactUserMessage() and StackTraceReport()

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -88,6 +88,21 @@ type UserMessager interface {
 	UserMessage() string
 }
 
+// CompactUserMessager returns a user message associated with the error
+type CompactUserMessager interface {
+	// CompactUserMessage formats the wraoped error message as a compact go-style
+	// wrapped error message. This format is more user-friendly and contains no
+	// new line nor tab (except the ones already present in the wrapped error).
+	// For example:
+	//
+	//	trace.Wrap(trace.Wrap(trace.Errorf("foo"), "bar"), "baz")
+	//
+	// Will produce the following compact error:
+	//
+	//	foo: bar: baz
+	CompactUserMessage() string
+}
+
 // ErrorWrapper wraps another error
 type ErrorWrapper interface {
 	// OrigError returns the wrapped error
@@ -100,6 +115,11 @@ type DebugReporter interface {
 	DebugReport() string
 }
 
+// StackTraceReporter returns the error stacktrace.
+type StackTraceReporter interface {
+	StackTraceReport() Traces
+}
+
 // UserMessage returns user-friendly part of the error
 func UserMessage(err error) string {
 	if err == nil {
@@ -107,6 +127,26 @@ func UserMessage(err error) string {
 	}
 	if wrap, ok := err.(UserMessager); ok {
 		return wrap.UserMessage()
+	}
+	return err.Error()
+}
+
+// CompactUserMessage formats the wraoped error message as a compact go-style
+// wrapped error message. This format is more user-friendly and contains no
+// new line nor tab (except the ones already present in the wrapped error).
+// For example:
+//
+//	trace.Wrap(trace.Wrap(trace.Errorf("foo"), "bar"), "baz")
+//
+// Will produce the following compact error:
+//
+//	foo: bar: baz
+func CompactUserMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	if wrap, ok := err.(CompactUserMessager); ok {
+		return wrap.CompactUserMessage()
 	}
 	return err.Error()
 }
@@ -170,6 +210,17 @@ func GetFields(err error) map[string]interface{} {
 	}
 
 	return map[string]interface{}{}
+}
+
+// StackTraceReport returns the error stacktrace if it was captured.
+func StackTraceReport(err error) Traces {
+	if err == nil {
+		return Traces{}
+	}
+	if wrap, ok := err.(StackTraceReporter); ok {
+		return wrap.StackTraceReport()
+	}
+	return Traces{}
 }
 
 // WrapWithMessage wraps the original error into Error and adds user message if any
@@ -374,6 +425,43 @@ func (e *TraceErr) GoString() string {
 	return e.DebugReport()
 }
 
+// CompactUserMessage formats the wraoped error message as a compact go-style
+// wrapped error message. This format is more user-friendly and contains no
+// new line nor tab (except the ones already present in the wrapped error).
+// For example:
+//
+//	trace.Wrap(trace.Wrap(trace.Errorf("foo"), "bar"), "baz")
+//
+// Will produce the following compact error:
+//
+//	foo: bar: baz
+func (e *TraceErr) CompactUserMessage() string {
+	if len(e.Messages) > 0 {
+		sb := strings.Builder{}
+		for i := len(e.Messages) - 1; i >= 0; i-- {
+			sb.WriteString(e.Messages[i])
+			sb.WriteString(": ")
+		}
+		sb.WriteString(e.Err.Error())
+		return sb.String()
+	}
+	if e.Message != "" {
+		// For backwards compatibility return the old user message if it's present.
+		return e.Message
+	}
+	return CompactUserMessage(e.Err)
+}
+
+// StackTraceReport returns the error stacktrace.
+func (e *TraceErr) StackTraceReport() Traces {
+	if len(e.Traces) > 0 {
+		traces := make(Traces, len(e.Traces))
+		copy(traces, e.Traces)
+		return traces
+	}
+	return StackTraceReport(e.Err)
+}
+
 // maxHops is a max supported nested depth for errors
 const maxHops = 50
 
@@ -387,6 +475,8 @@ type Error interface {
 	ErrorWrapper
 	DebugReporter
 	UserMessager
+	CompactUserMessager
+	StackTraceReporter
 
 	// GetFields returns any fields that have been added to the error
 	GetFields() map[string]interface{}

--- a/trace_test.go
+++ b/trace_test.go
@@ -34,8 +34,11 @@ import (
 func TestEmpty(t *testing.T) {
 	assert.Equal(t, "", DebugReport(nil))
 	assert.Equal(t, "", UserMessage(nil))
+	assert.Equal(t, "", CompactUserMessage(nil))
 	assert.Equal(t, "", UserMessageWithFields(nil))
 	assert.Equal(t, map[string]interface{}{}, GetFields(nil))
+	var err TraceErr
+	assert.Equal(t, Traces{}, err.StackTraceReport())
 }
 
 func TestWrap(t *testing.T) {
@@ -45,7 +48,10 @@ func TestWrap(t *testing.T) {
 	assert.Regexp(t, ".*trace_test.go.*", line(DebugReport(err)))
 	assert.NotRegexp(t, ".*trace.go.*", line(DebugReport(err)))
 	assert.NotRegexp(t, ".*trace_test.go.*", line(UserMessage(err)))
+	assert.NotRegexp(t, ".*trace_test.go.*", line(CompactUserMessage(err)))
 	assert.Regexp(t, ".*param.*", line(UserMessage(err)))
+	assert.Regexp(t, ".*param.*", line(CompactUserMessage(err)))
+	assert.Regexp(t, ".*trace_test.go.*", err.StackTraceReport()[0].Path)
 }
 
 func TestOrigError(t *testing.T) {
@@ -67,15 +73,18 @@ func TestWrapUserMessage(t *testing.T) {
 	assert.Regexp(t, ".*trace_test.go.*", line(DebugReport(err)))
 	assert.NotRegexp(t, ".*trace.go.*", line(DebugReport(err)))
 	assert.Equal(t, "user message\tdescription", line(UserMessage(err)))
+	assert.Equal(t, "user message: description", CompactUserMessage(err))
 
 	err = Wrap(err, "user message 2")
 	assert.Equal(t, "user message 2\tuser message\t\tdescription", line(UserMessage(err)))
+	assert.Equal(t, "user message 2: user message: description", CompactUserMessage(err))
 }
 
 func TestWrapWithMessage(t *testing.T) {
 	testErr := fmt.Errorf("description")
 	err := WrapWithMessage(testErr, "user message")
 	assert.Equal(t, "user message\tdescription", line(UserMessage(err)))
+	assert.Equal(t, "user message: description", CompactUserMessage(err))
 	assert.Regexp(t, ".*trace_test.go.*", line(DebugReport(err)))
 	assert.NotRegexp(t, ".*trace.go.*", line(DebugReport(err)))
 }
@@ -104,6 +113,18 @@ func TestGetFields(t *testing.T) {
 	// ensure that you can get fields from a proxyError
 	e := roundtripError(err)
 	assert.Equal(t, fields, GetFields(e))
+}
+
+func TestStackTraceReport(t *testing.T) {
+	testErr := fmt.Errorf("description")
+	assert.Equal(t, Traces{}, StackTraceReport(testErr))
+
+	err := Wrap(testErr, "user message")
+	stackTrace := StackTraceReport(err)
+	assert.Len(t, stackTrace, 3)
+	assert.Equal(t, stackTrace[0].Func, "github.com/gravitational/trace.TestGetStackTrace")
+	assert.Equal(t, stackTrace[1].Func, "testing.tRunner")
+	assert.Equal(t, stackTrace[2].Func, "runtime.goexit")
 }
 
 func roundtripError(err error) error {

--- a/trace_test.go
+++ b/trace_test.go
@@ -122,7 +122,7 @@ func TestStackTraceReport(t *testing.T) {
 	err := Wrap(testErr, "user message")
 	stackTrace := StackTraceReport(err)
 	assert.Len(t, stackTrace, 3)
-	assert.Equal(t, stackTrace[0].Func, "github.com/gravitational/trace.TestGetStackTrace")
+	assert.Equal(t, stackTrace[0].Func, "github.com/gravitational/trace.TestStackTraceReport")
 	assert.Equal(t, stackTrace[1].Func, "testing.tRunner")
 	assert.Equal(t, stackTrace[2].Func, "runtime.goexit")
 }


### PR DESCRIPTION
This PR adds a couple of new functions in an attempt to improve error logging in teleport projects.
**The goal is not to make `trace/v2`**, I tried a year ago and was not convinced by [the result](https://github.com/gravitational/teleport/pull/36071). I have not given up on making trace more aligned with go's wrapping and will likely resurrect the RFD at some point.

This PR introduces new functions instead of changing `TraceErr.Error()`, this ensures the changes can be backported (this is a requirement for the teleport-updater). This also allows us to experiment with error formats before doing a `trace/v2`.

The main motivation for this PR is to have user-friendly error logging in the teleport-updater. During the implementation, I found the great [loggin RFD](https://github.com/gravitational/teleport/pull/17305) written by @programmerq . While I'm not trying to implement it completely, the changes this PR proposes are aligned with the RFD suggestions of making shorter single-line error messages and decluttering the stacktrace debug report.

The goal is to:

### provide concise go-style error messages for wrapped error:

The standard go practice is to wrap with `fmt.Errorf("callsite info: %w", err)`. This creates error messages looking like `callsite info: my error message`. The error message fits in a single line and is friendly both for JSON logging and Text logging. Multiline errors add `\n` in the first and clutters the log output in the latter.

### improved structured logging support for traced errors

Currently the trace is contained in the DebugReport, a large multiline string that was intended for CLI troubleshooting. Debug reports are currently not logged properly by the JSON logger, and clutter the server logs when used with the Text logger. Exposing the structured trace will allow the structured logger to log it properly, regardless of the logging output.