### PR TITLE
Add support for CLI-formatted errors and allow for dead code elimination

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -23,7 +23,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
+	"html"
+	"maps"
+	"slices"
 	"strings"
 	"sync/atomic"
 
@@ -95,9 +97,18 @@ type ErrorWrapper interface {
 }
 
 // DebugReporter formats an error for display
+// Depreciated: Use `FormattedDebugReporter` instead.
 type DebugReporter interface {
 	// DebugReport formats an error for display
 	DebugReport() string
+}
+
+// FormattedDebugReporter formats an error in different output formats
+type FormattedDebugReporter interface {
+	// HTML-escaped error message formatted for browser display
+	DebugReportHTML() string
+	// Unescaped error message formatted for CLI display
+	DebugReportCLI() string
 }
 
 // UserMessage returns user-friendly part of the error
@@ -130,16 +141,33 @@ func UserMessageWithFields(err error) string {
 	return err.Error()
 }
 
-// DebugReport returns debug report with all known information
+// DebugReportHTML returns a HTML escaped debug report with all known information
 // about the error including stack trace if it was captured
-func DebugReport(err error) string {
+func DebugReportHTML(err error) string {
 	if err == nil {
 		return ""
 	}
-	if reporter, ok := err.(DebugReporter); ok {
-		return reporter.DebugReport()
+	if reporter, ok := err.(FormattedDebugReporter); ok {
+		return reporter.DebugReportHTML()
 	}
 	return err.Error()
+}
+
+// DebugReportCLI returns an unescaped debug report with all known information
+// about the error including stack trace if it was captured
+func DebugReportCLI(err error) string {
+	if err == nil {
+		return ""
+	}
+	if reporter, ok := err.(FormattedDebugReporter); ok {
+		return reporter.DebugReportCLI()
+	}
+	return err.Error()
+}
+
+// Depreciated: Use `DebugReportHTML` or `DebugReportCLI` instead
+func DebugReport(err error) string {
+	return DebugReportHTML(err)
 }
 
 // GetFields returns any fields that have been added to the error message
@@ -316,20 +344,28 @@ func (e *TraceErr) UserMessage() string {
 	return UserMessage(e.Err)
 }
 
-// DebugReport returns developer-friendly error report
+// Depreciated: Use `DebugReportHTML` or `DebugReportCLI` instead.
 func (e *TraceErr) DebugReport() string {
-	var buf bytes.Buffer
-	err := reportTemplate.Execute(&buf, errorReport{
+	return e.DebugReportHTML()
+}
+
+func (e *TraceErr) toErrorReport() *errorReport {
+	return &errorReport{
 		OrigErrType:    fmt.Sprintf("%T", e.Err),
 		OrigErrMessage: e.Err.Error(),
 		Fields:         e.Fields,
 		StackTrace:     e.Traces.String(),
 		UserMessage:    e.UserMessage(),
-	})
-	if err != nil {
-		return fmt.Sprint("error generating debug report: ", err.Error())
 	}
-	return buf.String()
+}
+
+// DebugReport returns developer-friendly, HTML escaped error report
+func (e *TraceErr) DebugReportHTML() string {
+	return e.toErrorReport().htmlEscape().message()
+}
+
+func (e *TraceErr) DebugReportCLI() string {
+	return e.toErrorReport().message()
 }
 
 // Error returns user-friendly error message when not in debug mode
@@ -371,7 +407,7 @@ func (e *TraceErr) OrigError() error {
 // GoString formats this trace object for use with
 // the "%#v" format string
 func (e *TraceErr) GoString() string {
-	return e.DebugReport()
+	return e.DebugReportHTML()
 }
 
 // maxHops is a max supported nested depth for errors
@@ -547,25 +583,35 @@ func wrapProxy(err error) Error {
 	}
 }
 
+// Depreciated: Use `DebugReportHTML` or `DebugReportCLI` instead
 // DebugReport formats the underlying error for display
 // Implements DebugReporter
 func (r proxyError) DebugReport() string {
+	return r.DebugReportHTML()
+}
+
+// DebugReportHTML formats the underlying error for browser display
+// Implements FormattedDebugReporter
+func (r proxyError) DebugReportHTML() string {
 	var wrappedErr *TraceErr
 	var ok bool
 	if wrappedErr, ok = r.TraceErr.Err.(*TraceErr); !ok {
-		return DebugReport(r.TraceErr)
+		return DebugReportHTML(r.TraceErr)
 	}
-	var buf bytes.Buffer
-	//nolint:errcheck
-	reportTemplate.Execute(&buf, errorReport{
-		OrigErrType:    fmt.Sprintf("%T", wrappedErr.Err),
-		OrigErrMessage: wrappedErr.Err.Error(),
-		Fields:         wrappedErr.Fields,
-		StackTrace:     wrappedErr.Traces.String(),
-		UserMessage:    wrappedErr.UserMessage(),
-		Caught:         r.TraceErr.Traces.String(),
-	})
-	return buf.String()
+
+	return wrappedErr.toErrorReport().htmlEscape().message()
+}
+
+// DebugReportCLI formats the underlying error for CLI display
+// Implements FormattedDebugReporter
+func (r proxyError) DebugReportCLI() string {
+	var wrappedErr *TraceErr
+	var ok bool
+	if wrappedErr, ok = r.TraceErr.Err.(*TraceErr); !ok {
+		return DebugReportCLI(r.TraceErr)
+	}
+
+	return wrappedErr.toErrorReport().message()
 }
 
 // GoString formats this trace object for use with
@@ -595,17 +641,55 @@ type errorReport struct {
 	Caught string
 }
 
-var (
-	reportTemplate     = template.Must(template.New("debugReport").Parse(reportTemplateText))
-	reportTemplateText = `
-ERROR REPORT:
-Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
-{{if .Fields}}Fields:
-{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
-{{end}}{{end}}Stack Trace:
-{{.StackTrace}}
-{{if .Caught}}Caught:
-{{.Caught}}
-User Message: {{.UserMessage}}
-{{else}}User Message: {{.UserMessage}}{{end}}`
-)
+// Produce an unescaped message for the report.
+func (er *errorReport) message() string {
+	// Using a string builder instead of a template allows for dead code elimination at the cost
+	// of code that is a little more difficult to read.
+	var messageBuilder strings.Builder
+	// Note: docs explicitly state that the returned error is nil. No need to check it here.
+	messageBuilder.WriteString("\nERROR REPORT:\n")
+	fmt.Fprintf(&messageBuilder, "Original Error: %s %s\n", er.OrigErrType, er.OrigErrMessage)
+
+	if len(er.Fields) > 0 {
+		messageBuilder.WriteString("Fields:\n")
+
+		// Sort keys to produce a deterministic output. This makes messages
+		// easier to read.
+		keys := slices.Sorted(maps.Keys(er.Fields))
+		for _, key := range keys {
+			value := er.Fields[key]
+			fmt.Fprintf(&messageBuilder, "  %s: %v\n", key, value)
+		}
+	}
+	messageBuilder.WriteString("Stack Trace:\n")
+	messageBuilder.WriteString(er.StackTrace)
+	messageBuilder.WriteString("\n")
+
+	if len(er.Caught) > 0 {
+		messageBuilder.WriteString("Caught:\n")
+		messageBuilder.WriteString(er.Caught)
+		messageBuilder.WriteString("\n")
+	}
+
+	fmt.Fprintf(&messageBuilder, "User Message: %s", er.UserMessage)
+
+	return messageBuilder.String()
+}
+
+// HTML escapes all fields, returning a new, escaped report
+func (er *errorReport) htmlEscape() *errorReport {
+	newReport := &errorReport{
+		OrigErrType:    html.EscapeString(er.OrigErrType),
+		OrigErrMessage: html.EscapeString(er.OrigErrMessage),
+		Fields:         make(map[string]interface{}, len(er.Fields)),
+		StackTrace:     html.EscapeString(er.StackTrace),
+		UserMessage:    html.EscapeString(er.UserMessage),
+		Caught:         html.EscapeString(er.Caught),
+	}
+
+	for key, value := range er.Fields {
+		newReport.Fields[html.EscapeString(key)] = html.EscapeString(fmt.Sprintf("%v", value))
+	}
+
+	return newReport
+}

--- a/trace_test.go
+++ b/trace_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package trace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"os"
@@ -31,8 +33,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func forEachReporter(t *testing.T, test func(t *testing.T, reporter func(error) string)) {
+	tests := []struct {
+		desc     string
+		reporter func(error) string
+	}{
+		{
+			desc:     "DebugReport",
+			reporter: DebugReport,
+		},
+		{
+			desc:     "DebugReportHTML",
+			reporter: DebugReportHTML,
+		},
+		{
+			desc:     "DebugReportCLI",
+			reporter: DebugReportCLI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			test(t, tt.reporter)
+		})
+	}
+}
+
 func TestEmpty(t *testing.T) {
-	assert.Equal(t, "", DebugReport(nil))
+	forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+		assert.Equal(t, "", reporter(nil))
+	})
 	assert.Equal(t, "", UserMessage(nil))
 	assert.Equal(t, "", UserMessageWithFields(nil))
 	assert.Equal(t, map[string]interface{}{}, GetFields(nil))
@@ -42,10 +72,12 @@ func TestWrap(t *testing.T) {
 	testErr := &testError{Param: "param"}
 	err := Wrap(Wrap(testErr))
 
-	assert.Regexp(t, ".*trace_test.go.*", line(DebugReport(err)))
-	assert.NotRegexp(t, ".*trace.go.*", line(DebugReport(err)))
-	assert.NotRegexp(t, ".*trace_test.go.*", line(UserMessage(err)))
+	forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+		assert.Regexp(t, ".*trace_test.go.*", line(reporter(err)))
+		assert.NotRegexp(t, ".*trace.go.*", line(reporter(err)))
+	})
 	assert.Regexp(t, ".*param.*", line(UserMessage(err)))
+	assert.NotRegexp(t, ".*trace_test.go.*", line(UserMessage(err)))
 }
 
 func TestOrigError(t *testing.T) {
@@ -64,8 +96,10 @@ func TestWrapUserMessage(t *testing.T) {
 	testErr := fmt.Errorf("description")
 
 	err := Wrap(testErr, "user message")
-	assert.Regexp(t, ".*trace_test.go.*", line(DebugReport(err)))
-	assert.NotRegexp(t, ".*trace.go.*", line(DebugReport(err)))
+	forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+		assert.Regexp(t, ".*trace_test.go.*", line(reporter(err)))
+		assert.NotRegexp(t, ".*trace.go.*", line(reporter(err)))
+	})
 	assert.Equal(t, "user message\tdescription", line(UserMessage(err)))
 
 	err = Wrap(err, "user message 2")
@@ -76,8 +110,10 @@ func TestWrapWithMessage(t *testing.T) {
 	testErr := fmt.Errorf("description")
 	err := WrapWithMessage(testErr, "user message")
 	assert.Equal(t, "user message\tdescription", line(UserMessage(err)))
-	assert.Regexp(t, ".*trace_test.go.*", line(DebugReport(err)))
-	assert.NotRegexp(t, ".*trace.go.*", line(DebugReport(err)))
+	forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+		assert.Regexp(t, ".*trace_test.go.*", line(reporter(err)))
+		assert.NotRegexp(t, ".*trace.go.*", line(reporter(err)))
+	})
 }
 
 func TestUserMessageWithFields(t *testing.T) {
@@ -235,9 +271,11 @@ func TestGenericErrors(t *testing.T) {
 		}
 
 		assert.NotEmpty(t, traceErr.Traces, testCase.comment)
-		assert.Regexp(t, ".*.trace_test\\.go.*", line(DebugReport(err)), testCase.comment)
-		assert.NotRegexp(t, ".*.errors\\.go.*", line(DebugReport(err)), testCase.comment)
-		assert.NotRegexp(t, ".*.trace\\.go.*", line(DebugReport(err)), testCase.comment)
+		forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+			assert.Regexp(t, ".*.trace_test\\.go.*", line(reporter(err)), testCase.comment)
+			assert.NotRegexp(t, ".*.errors\\.go.*", line(reporter(err)), testCase.comment)
+			assert.NotRegexp(t, ".*.trace\\.go.*", line(reporter(err)), testCase.comment)
+		})
 		assert.True(t, testCase.Predicate(err), testCase.comment)
 
 		w := newTestWriter()
@@ -310,14 +348,18 @@ func TestAggregates(t *testing.T) {
 
 func TestErrorf(t *testing.T) {
 	err := Errorf("error")
-	assert.Regexp(t, ".*.trace_test.go.*", line(DebugReport(err)))
-	assert.NotRegexp(t, ".*.Fields.*", line(DebugReport(err)))
+	forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+		assert.Regexp(t, ".*.trace_test.go.*", line(reporter(err)))
+		assert.NotRegexp(t, ".*.Fields.*", line(reporter(err)))
+	})
 	assert.Equal(t, []string(nil), err.(*TraceErr).Messages)
 }
 
 func TestWithField(t *testing.T) {
 	err := WithField(Wrap(Errorf("error")), "testfield", true)
-	assert.Regexp(t, ".*.testfield.*", line(DebugReport(err)))
+	forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+		assert.Regexp(t, ".*.testfield.*", line(reporter(err)))
+	})
 }
 
 func TestWithFields(t *testing.T) {
@@ -325,9 +367,84 @@ func TestWithFields(t *testing.T) {
 		"testfield1": true,
 		"testfield2": "value2",
 	})
-	assert.Regexp(t, ".*.Fields.*", line(DebugReport(err)))
-	assert.Regexp(t, ".*.testfield1: true.*", line(DebugReport(err)))
-	assert.Regexp(t, ".*.testfield2: value2.*", line(DebugReport(err)))
+	forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+		assert.Regexp(t, ".*.Fields.*", line(reporter(err)))
+		assert.Regexp(t, ".*.testfield1: true.*", line(reporter(err)))
+		assert.Regexp(t, ".*.testfield2: value2.*", line(reporter(err)))
+	})
+}
+
+// Needed for backwards compat
+func TestDebugReportMatchesDebugReportHTML(t *testing.T) {
+	rawErr := Errorf("inner error")
+	err := Wrap(rawErr, "middle error")
+	err = Wrap(err, "outer error")
+	err = WithFields(err, map[string]interface{}{
+		"key1": "\"<>&'azAZ1,./ string field with special characters",
+		"key2": Errorf("non-string in second field"),
+	})
+	err = WithUserMessage(err, "some multiline user error\n    line 2")
+
+	assert.Equal(t, DebugReport(err), DebugReportHTML(err))
+}
+
+// Produce a debug report using a reflection-backed template for historical reasons
+func oldDebugReport(traceErr *TraceErr) string {
+	reportTemplateText := `
+ERROR REPORT:
+Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
+{{if .Fields}}Fields:
+{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
+{{end}}{{end}}Stack Trace:
+{{.StackTrace}}
+{{if .Caught}}Caught:
+{{.Caught}}
+User Message: {{.UserMessage}}
+{{else}}User Message: {{.UserMessage}}{{end}}`
+	reportTemplate := template.Must(template.New("debugReport").Parse(reportTemplateText))
+
+	var buf bytes.Buffer
+	//nolint:errcheck
+	reportTemplate.Execute(&buf, traceErr.toErrorReport())
+
+	return buf.String()
+}
+
+// Needed for backwards compat
+func TestDebugReportMatchesTemplate(t *testing.T) {
+	dummyVal := struct {
+		key1 string
+		key2 bool
+		key3 int
+	}{
+		key1: "val 1",
+		key2: true,
+		key3: 123456,
+	}
+
+	rawErr := Errorf("inner error %q", "quoted value")
+	err := Wrap(rawErr, "middle error %#v", dummyVal)
+	err = Wrap(err, "outer error")
+	err = WithField(err, "key", "\"<>&'azAZ1,./ string field with special characters")
+	traceErr := WithUserMessage(err, "some multiline user error\n    line 2")
+
+	debugReportMessage := DebugReport(traceErr)
+	oldTemplatedMessage := oldDebugReport(traceErr)
+	require.Equal(t, oldTemplatedMessage, debugReportMessage)
+}
+
+func TestCLIReportDoesNotEscapeHTML(t *testing.T) {
+	rawErr := Errorf("inner error <>&'azAZ1,./")
+	err := Wrap(rawErr, "middle error <>&'azAZ1,./")
+	err = Wrap(err, "outer error <>&'azAZ1,./")
+	err = WithField(err, "key", "\"<>&'azAZ1,./ string field 1 with special characters")
+	err = WithUserMessage(err, "some multiline user error\n    line 2 <>&'azAZ1,./")
+
+	message := DebugReportCLI(err)
+
+	// Escaped HTML charts always end in `;`. For this test to be effective,
+	// a semicolon character should not appear in the error.
+	assert.NotContains(t, message, ';')
 }
 
 func TestAggregateConvertsToCommonErrors(t *testing.T) {
@@ -365,7 +482,9 @@ func TestAggregateConvertsToCommonErrors(t *testing.T) {
 		SetDebug(true)
 		err := testCase.Err
 
-		assert.Regexp(t, ".*.trace_test.go.*", line(DebugReport(err)), testCase.comment)
+		forEachReporter(t, func(t *testing.T, reporter func(error) string) {
+			assert.Regexp(t, ".*.trace_test.go.*", line(DebugReport(err)), testCase.comment)
+		})
 		assert.True(t, testCase.Predicate(err), testCase.comment)
 
 		w := newTestWriter()


### PR DESCRIPTION
The current `DebugReport` has a couple of issues:
* The error message fields are HTML-escaped. This makes them difficult to read in a CLI context, especially anywhere we do something like `trace.Errorf("some error message: %q", "some relevant information")`. Here's an example of what a debug report can currently produce:
    
	```
	ERROR REPORT:
	Original Error: *errors.errorString inner error &#34;quoted value&#34;
	Fields:
	key: &#34;&lt;&gt;&amp;&#39;azAZ1,./ string field with special characters
	Stack Trace:
		/Users/fredheinecke/trace/trace_test.go:425 github.com/gravitational/trace.TestDebugReportMatchesTemplate
		/opt/homebrew/Cellar/go/1.23.5/libexec/src/testing/testing.go:1690 testing.tRunner
		/opt/homebrew/Cellar/go/1.23.5/libexec/src/runtime/asm_arm64.s:1223 runtime.goexit
	User Message: some multiline user error
		line 2
		outer error
			middle error struct { key1 string; key2 bool; key3 int }{key1:&#34;val 1&#34;, key2:true, key3:123456}
				inner error &#34;quoted value&#34;
	```

    Error messages "bubbled up" through many layers in Teleport can have significantly more escaping, making logs painful to read.
* Using the golang templating removes the possibility of dead code elimination, because it calls `reflect.MethodByName`.

This PR adds a new interface (for backwards compatibility), which adds separate HTML and CLI debug report functions. The HTML versions produce identical error messages as the (now depreciated) `DebugReport()` functions. The CLI versions produce messages in the same format, but without any escaping.

The PR also changes the underlying templating implementation to use a string builder rather than a template. This makes the code slightly harder to read, but removes the reflection dependency. While this is unlikely to make any different in Teleport product binaries, it should reduce the binary size of some of our internal tools. It should have a positive impact on the ~600 non-Gravitational consumers of this library as well.