### PR TITLE
Remove use of html/template for DebugReports

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -23,13 +23,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"strings"
 	"sync/atomic"
 
-	"github.com/gravitational/trace/internal"
-
 	"golang.org/x/net/context"
+
+	"github.com/gravitational/trace/internal"
 )
 
 var debug int32
@@ -318,18 +317,24 @@ func (e *TraceErr) UserMessage() string {
 
 // DebugReport returns developer-friendly error report
 func (e *TraceErr) DebugReport() string {
-	var buf bytes.Buffer
-	err := reportTemplate.Execute(&buf, errorReport{
-		OrigErrType:    fmt.Sprintf("%T", e.Err),
-		OrigErrMessage: e.Err.Error(),
-		Fields:         e.Fields,
-		StackTrace:     e.Traces.String(),
-		UserMessage:    e.UserMessage(),
-	})
-	if err != nil {
-		return fmt.Sprint("error generating debug report: ", err.Error())
+	var sb strings.Builder
+	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
+	fmt.Fprintf(&sb, "%T ", e.Err)
+	sb.WriteString(e.Err.Error())
+	sb.WriteRune('\n')
+	if len(e.Fields) > 0 {
+		sb.WriteString("Fields:\n")
+		for k, v := range e.Fields {
+			fmt.Fprintf(&sb, "  %s: %v\n", k, v)
+		}
 	}
-	return buf.String()
+	sb.WriteString("Stack Trace:\n")
+	sb.WriteString(e.Traces.String())
+	sb.WriteRune('\n')
+	sb.WriteString("User Message: ")
+	sb.WriteString(e.UserMessage())
+
+	return sb.String()
 }
 
 // Error returns user-friendly error message when not in debug mode
@@ -550,22 +555,38 @@ func wrapProxy(err error) Error {
 // DebugReport formats the underlying error for display
 // Implements DebugReporter
 func (r proxyError) DebugReport() string {
-	var wrappedErr *TraceErr
-	var ok bool
-	if wrappedErr, ok = r.TraceErr.Err.(*TraceErr); !ok {
+	wrappedErr, ok := r.TraceErr.Err.(*TraceErr)
+	if !ok {
 		return DebugReport(r.TraceErr)
 	}
-	var buf bytes.Buffer
-	//nolint:errcheck
-	reportTemplate.Execute(&buf, errorReport{
-		OrigErrType:    fmt.Sprintf("%T", wrappedErr.Err),
-		OrigErrMessage: wrappedErr.Err.Error(),
-		Fields:         wrappedErr.Fields,
-		StackTrace:     wrappedErr.Traces.String(),
-		UserMessage:    wrappedErr.UserMessage(),
-		Caught:         r.TraceErr.Traces.String(),
-	})
-	return buf.String()
+
+	var sb strings.Builder
+	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
+	fmt.Fprintf(&sb, "%T ", wrappedErr.Err)
+	sb.WriteString(wrappedErr.Err.Error())
+	sb.WriteRune('\n')
+	if len(wrappedErr.Fields) > 0 {
+		sb.WriteString("Fields:\n")
+		for k, v := range wrappedErr.Fields {
+			fmt.Fprintf(&sb, "  %s: %v\n", k, v)
+		}
+	}
+	sb.WriteString("Stack Trace:\n")
+	sb.WriteString(wrappedErr.Traces.String())
+	sb.WriteRune('\n')
+	if caught := r.TraceErr.Traces.String(); caught != "" {
+		sb.WriteString("Caught:\n")
+		sb.WriteString(caught)
+		sb.WriteRune('\n')
+		sb.WriteString("User Message: ")
+		sb.WriteString(wrappedErr.UserMessage())
+		sb.WriteRune('\n')
+	} else {
+		sb.WriteString("User Message: ")
+		sb.WriteString(wrappedErr.UserMessage())
+	}
+
+	return sb.String()
 }
 
 // GoString formats this trace object for use with
@@ -594,18 +615,3 @@ type errorReport struct {
 	// has been recorded after coming over the wire
 	Caught string
 }
-
-var (
-	reportTemplate     = template.Must(template.New("debugReport").Parse(reportTemplateText))
-	reportTemplateText = `
-ERROR REPORT:
-Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
-{{if .Fields}}Fields:
-{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
-{{end}}{{end}}Stack Trace:
-{{.StackTrace}}
-{{if .Caught}}Caught:
-{{.Caught}}
-User Message: {{.UserMessage}}
-{{else}}User Message: {{.UserMessage}}{{end}}`
-)

--- a/trace.go
+++ b/trace.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
 	"strings"
 	"sync/atomic"
 
@@ -321,19 +320,23 @@ func (e *TraceErr) DebugReport() string {
 	var sb strings.Builder
 	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
 	fmt.Fprintf(&sb, "%T ", e.Err)
-	sb.WriteString(html.EscapeString(e.Err.Error()))
+	htmlEscaper.WriteString(&sb, e.Err.Error())
 	sb.WriteRune('\n')
 	if len(e.Fields) > 0 {
 		sb.WriteString("Fields:\n")
 		for k, v := range e.Fields {
-			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprint(v)))
+			sb.WriteString("  ")
+			htmlEscaper.WriteString(&sb, k)
+			sb.WriteString(": ")
+			htmlEscaper.WriteString(&sb, fmt.Sprint(v))
+			sb.WriteRune('\n')
 		}
 	}
 	sb.WriteString("Stack Trace:\n")
-	sb.WriteString(html.EscapeString(e.Traces.String()))
+	htmlEscaper.WriteString(&sb, e.Traces.String())
 	sb.WriteRune('\n')
 	sb.WriteString("User Message: ")
-	sb.WriteString(html.EscapeString(e.UserMessage()))
+	htmlEscaper.WriteString(&sb, e.UserMessage())
 
 	return sb.String()
 }
@@ -553,6 +556,14 @@ func wrapProxy(err error) Error {
 	}
 }
 
+var htmlEscaper = strings.NewReplacer(
+	`&`, "&amp;",
+	`'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+	`<`, "&lt;",
+	`>`, "&gt;",
+	`"`, "&#34;", // "&#34;" is shorter than "&quot;".
+)
+
 // DebugReport formats the underlying error for display
 // Implements DebugReporter
 func (r proxyError) DebugReport() string {
@@ -563,27 +574,31 @@ func (r proxyError) DebugReport() string {
 
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "\nERROR REPORT:\nOriginal Error: %T ", wrappedErr.Err)
-	sb.WriteString(html.EscapeString(wrappedErr.Err.Error()))
+	htmlEscaper.WriteString(&sb, wrappedErr.Err.Error())
 	sb.WriteRune('\n')
 	if len(wrappedErr.Fields) > 0 {
 		sb.WriteString("Fields:\n")
 		for k, v := range wrappedErr.Fields {
-			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprint(v)))
+			sb.WriteString("  ")
+			htmlEscaper.WriteString(&sb, k)
+			sb.WriteString(": ")
+			htmlEscaper.WriteString(&sb, fmt.Sprint(v))
+			sb.WriteRune('\n')
 		}
 	}
 	sb.WriteString("Stack Trace:\n")
-	sb.WriteString(html.EscapeString(wrappedErr.Traces.String()))
+	htmlEscaper.WriteString(&sb, wrappedErr.Traces.String())
 	sb.WriteRune('\n')
 	if caught := r.TraceErr.Traces.String(); caught != "" {
 		sb.WriteString("Caught:\n")
-		sb.WriteString(html.EscapeString(caught))
+		htmlEscaper.WriteString(&sb, caught)
 		sb.WriteRune('\n')
 		sb.WriteString("User Message: ")
-		sb.WriteString(html.EscapeString(wrappedErr.UserMessage()))
+		htmlEscaper.WriteString(&sb, wrappedErr.UserMessage())
 		sb.WriteRune('\n')
 	} else {
 		sb.WriteString("User Message: ")
-		sb.WriteString(html.EscapeString(wrappedErr.UserMessage()))
+		htmlEscaper.WriteString(&sb, wrappedErr.UserMessage())
 	}
 
 	return sb.String()

--- a/trace.go
+++ b/trace.go
@@ -326,7 +326,7 @@ func (e *TraceErr) DebugReport() string {
 	if len(e.Fields) > 0 {
 		sb.WriteString("Fields:\n")
 		for k, v := range e.Fields {
-			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprintf("%v", v)))
+			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprint(v)))
 		}
 	}
 	sb.WriteString("Stack Trace:\n")
@@ -562,14 +562,13 @@ func (r proxyError) DebugReport() string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
-	fmt.Fprintf(&sb, "%T ", wrappedErr.Err)
+	fmt.Fprintf(&sb, "\nERROR REPORT:\nOriginal Error: %T ", wrappedErr.Err)
 	sb.WriteString(html.EscapeString(wrappedErr.Err.Error()))
 	sb.WriteRune('\n')
 	if len(wrappedErr.Fields) > 0 {
 		sb.WriteString("Fields:\n")
 		for k, v := range wrappedErr.Fields {
-			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprintf("%v", v)))
+			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprint(v)))
 		}
 	}
 	sb.WriteString("Stack Trace:\n")

--- a/trace.go
+++ b/trace.go
@@ -599,19 +599,3 @@ func (r proxyError) GoString() string {
 type proxyError struct {
 	*TraceErr
 }
-
-type errorReport struct {
-	// OrigErrType specifies the error type as text
-	OrigErrType string
-	// OrigErrMessage specifies the original error's message
-	OrigErrMessage string
-	// Fields lists any additional fields attached to the error
-	Fields map[string]interface{}
-	// StackTrace specifies the call stack
-	StackTrace string
-	// UserMessage is the user-facing message (if any)
-	UserMessage string
-	// Caught optionally specifies the stack trace where the error
-	// has been recorded after coming over the wire
-	Caught string
-}

--- a/trace.go
+++ b/trace.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync/atomic"
 
@@ -319,7 +320,8 @@ func (e *TraceErr) UserMessage() string {
 func (e *TraceErr) DebugReport() string {
 	var sb strings.Builder
 	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
-	fmt.Fprintf(&sb, "%T ", e.Err)
+	sb.WriteString(reflect.TypeOf(e.Err).String())
+	sb.WriteRune(' ')
 	htmlEscaper.WriteString(&sb, e.Err.Error())
 	sb.WriteRune('\n')
 	if len(e.Fields) > 0 {
@@ -573,7 +575,9 @@ func (r proxyError) DebugReport() string {
 	}
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "\nERROR REPORT:\nOriginal Error: %T ", wrappedErr.Err)
+	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
+	sb.WriteString(reflect.TypeOf(wrappedErr.Err).String())
+	sb.WriteRune(' ')
 	htmlEscaper.WriteString(&sb, wrappedErr.Err.Error())
 	sb.WriteRune('\n')
 	if len(wrappedErr.Fields) > 0 {

--- a/trace.go
+++ b/trace.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"strings"
 	"sync/atomic"
 
@@ -320,19 +321,19 @@ func (e *TraceErr) DebugReport() string {
 	var sb strings.Builder
 	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
 	fmt.Fprintf(&sb, "%T ", e.Err)
-	sb.WriteString(e.Err.Error())
+	sb.WriteString(html.EscapeString(e.Err.Error()))
 	sb.WriteRune('\n')
 	if len(e.Fields) > 0 {
 		sb.WriteString("Fields:\n")
 		for k, v := range e.Fields {
-			fmt.Fprintf(&sb, "  %s: %v\n", k, v)
+			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprintf("%v", v)))
 		}
 	}
 	sb.WriteString("Stack Trace:\n")
-	sb.WriteString(e.Traces.String())
+	sb.WriteString(html.EscapeString(e.Traces.String()))
 	sb.WriteRune('\n')
 	sb.WriteString("User Message: ")
-	sb.WriteString(e.UserMessage())
+	sb.WriteString(html.EscapeString(e.UserMessage()))
 
 	return sb.String()
 }
@@ -563,27 +564,27 @@ func (r proxyError) DebugReport() string {
 	var sb strings.Builder
 	sb.WriteString("\nERROR REPORT:\nOriginal Error: ")
 	fmt.Fprintf(&sb, "%T ", wrappedErr.Err)
-	sb.WriteString(wrappedErr.Err.Error())
+	sb.WriteString(html.EscapeString(wrappedErr.Err.Error()))
 	sb.WriteRune('\n')
 	if len(wrappedErr.Fields) > 0 {
 		sb.WriteString("Fields:\n")
 		for k, v := range wrappedErr.Fields {
-			fmt.Fprintf(&sb, "  %s: %v\n", k, v)
+			fmt.Fprintf(&sb, "  %s: %s\n", html.EscapeString(k), html.EscapeString(fmt.Sprintf("%v", v)))
 		}
 	}
 	sb.WriteString("Stack Trace:\n")
-	sb.WriteString(wrappedErr.Traces.String())
+	sb.WriteString(html.EscapeString(wrappedErr.Traces.String()))
 	sb.WriteRune('\n')
 	if caught := r.TraceErr.Traces.String(); caught != "" {
 		sb.WriteString("Caught:\n")
-		sb.WriteString(caught)
+		sb.WriteString(html.EscapeString(caught))
 		sb.WriteRune('\n')
 		sb.WriteString("User Message: ")
-		sb.WriteString(wrappedErr.UserMessage())
+		sb.WriteString(html.EscapeString(wrappedErr.UserMessage()))
 		sb.WriteRune('\n')
 	} else {
 		sb.WriteString("User Message: ")
-		sb.WriteString(wrappedErr.UserMessage())
+		sb.WriteString(html.EscapeString(wrappedErr.UserMessage()))
 	}
 
 	return sb.String()

--- a/trace_test.go
+++ b/trace_test.go
@@ -859,3 +859,27 @@ func TestAggregate_IsError(t *testing.T) {
 	assert.ErrorIs(t, errAggregate, err3)
 	assert.NotErrorIs(t, errAggregate, errUnrelated)
 }
+
+func BenchmarkDebugReport(b *testing.B) {
+	err := proxyError{
+		TraceErr: &TraceErr{
+			Err: &TraceErr{
+				Err: &BadParameterError{Message: `a < b & c > d "e"`},
+				Traces: Traces{
+					{Path: "/a/b/c", Line: 109, Func: "abcd"},
+					{Path: "/q/p/r", Line: 120, Func: "lkjh"},
+				},
+				Fields:   map[string]interface{}{"k<ey": "v<al&ue>"},
+				Messages: []string{`<script>alert("xss")</script>`},
+			},
+			Traces: Traces{
+				{Path: "/x/y/z", Line: 200, Func: "efgh"},
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		report := err.DebugReport()
+		require.NotEmpty(b, report)
+	}
+}

--- a/trace_test.go
+++ b/trace_test.go
@@ -48,6 +48,22 @@ User Message: {{.UserMessage}}
 {{else}}User Message: {{.UserMessage}}{{end}}`
 )
 
+type errorReport struct {
+	// OrigErrType specifies the error type as text
+	OrigErrType string
+	// OrigErrMessage specifies the original error's message
+	OrigErrMessage string
+	// Fields lists any additional fields attached to the error
+	Fields map[string]any
+	// StackTrace specifies the call stack
+	StackTrace string
+	// UserMessage is the user-facing message (if any)
+	UserMessage string
+	// Caught optionally specifies the stack trace where the error
+	// has been recorded after coming over the wire
+	Caught string
+}
+
 // OldProxyErrorDebugReport generates a DebugReport by leveraging the
 // [reportTemplateText] template. This was moved when the DebugReport
 // implementation changed to validate the output matches.

--- a/trace_test.go
+++ b/trace_test.go
@@ -221,19 +221,19 @@ func TestTraceErrDebugReport(t *testing.T) {
 	innerErr := &BadParameterError{Message: "bad param"}
 
 	tests := []struct {
-		name  string
-		error *TraceErr
+		name string
+		err  *TraceErr
 	}{
 		{
 			name: "basic",
-			error: &TraceErr{
+			err: &TraceErr{
 				Err:    innerErr,
 				Traces: traces,
 			},
 		},
 		{
 			name: "with fields",
-			error: &TraceErr{
+			err: &TraceErr{
 				Err:    innerErr,
 				Traces: traces,
 				Fields: map[string]interface{}{"key": "value"},
@@ -241,7 +241,7 @@ func TestTraceErrDebugReport(t *testing.T) {
 		},
 		{
 			name: "with message",
-			error: &TraceErr{
+			err: &TraceErr{
 				Err:     innerErr,
 				Traces:  traces,
 				Message: "legacy user message",
@@ -249,7 +249,7 @@ func TestTraceErrDebugReport(t *testing.T) {
 		},
 		{
 			name: "with messages",
-			error: &TraceErr{
+			err: &TraceErr{
 				Err:      innerErr,
 				Traces:   traces,
 				Messages: []string{"msg1", "msg2"},
@@ -257,7 +257,7 @@ func TestTraceErrDebugReport(t *testing.T) {
 		},
 		{
 			name: "html special characters",
-			error: &TraceErr{
+			err: &TraceErr{
 				Err:      &BadParameterError{Message: `a < b & c > d "e"`},
 				Traces:   traces,
 				Fields:   map[string]interface{}{"k<ey": "v<al&ue>"},
@@ -268,7 +268,7 @@ func TestTraceErrDebugReport(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, OldTraceErrorDebugReport(test.error), test.error.DebugReport())
+			require.Equal(t, OldTraceErrorDebugReport(test.err), test.err.DebugReport())
 		})
 	}
 }

--- a/trace_test.go
+++ b/trace_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package trace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"os"
@@ -30,6 +32,207 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var (
+	reportTemplate     = template.Must(template.New("debugReport").Parse(reportTemplateText))
+	reportTemplateText = `
+ERROR REPORT:
+Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
+{{if .Fields}}Fields:
+{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
+{{end}}{{end}}Stack Trace:
+{{.StackTrace}}
+{{if .Caught}}Caught:
+{{.Caught}}
+User Message: {{.UserMessage}}
+{{else}}User Message: {{.UserMessage}}{{end}}`
+)
+
+// OldProxyErrorDebugReport generates a DebugReport by leveraging the
+// [reportTemplateText] template. This was moved when the DebugReport
+// implementation changed to validate the output matches.
+func OldProxyErrorDebugReport(r proxyError) string {
+	wrappedErr, ok := r.TraceErr.Err.(*TraceErr)
+	if !ok {
+		return DebugReport(r.TraceErr)
+	}
+	var buf bytes.Buffer
+	err := reportTemplate.Execute(&buf, errorReport{
+		OrigErrType:    fmt.Sprintf("%T", wrappedErr.Err),
+		OrigErrMessage: wrappedErr.Err.Error(),
+		Fields:         wrappedErr.Fields,
+		StackTrace:     wrappedErr.Traces.String(),
+		UserMessage:    wrappedErr.UserMessage(),
+		Caught:         r.TraceErr.Traces.String(),
+	})
+	if err != nil {
+		return fmt.Sprint("error generating debug report: ", err.Error())
+	}
+	return buf.String()
+}
+
+// OldTraceErrorDebugReport generates a DebugReport by leveraging the
+// [reportTemplateText] template. This was moved when the DebugReport
+// implementation changed to validate the output matches.
+func OldTraceErrorDebugReport(e *TraceErr) string {
+	var buf bytes.Buffer
+	err := reportTemplate.Execute(&buf, errorReport{
+		OrigErrType:    fmt.Sprintf("%T", e.Err),
+		OrigErrMessage: e.Err.Error(),
+		Fields:         e.Fields,
+		StackTrace:     e.Traces.String(),
+		UserMessage:    e.UserMessage(),
+	})
+	if err != nil {
+		return fmt.Sprint("error generating debug report: ", err.Error())
+	}
+	return buf.String()
+}
+
+func TestProxyErrorDebugReport(t *testing.T) {
+	innerTraces := Traces{
+		{Path: "/a/b/c", Line: 109, Func: "abcd"},
+		{Path: "/q/p/r", Line: 120, Func: "lkjh"},
+	}
+	caughtTraces := Traces{
+		{Path: "/x/y/z", Line: 200, Func: "efgh"},
+	}
+	innerErr := &BadParameterError{Message: "bad param"}
+
+	tests := []struct {
+		name string
+		err  proxyError
+	}{
+		{
+			name: "basic",
+			err: proxyError{
+				TraceErr: &TraceErr{
+					Err: &TraceErr{
+						Err:    innerErr,
+						Traces: innerTraces,
+					},
+					Traces: caughtTraces,
+				},
+			},
+		},
+		{
+			name: "with fields",
+			err: proxyError{
+				TraceErr: &TraceErr{
+					Err: &TraceErr{
+						Err:    innerErr,
+						Traces: innerTraces,
+						Fields: map[string]interface{}{"key": "value"},
+					},
+					Traces: caughtTraces,
+				},
+			},
+		},
+		{
+			name: "no caught traces",
+			err: proxyError{
+				TraceErr: &TraceErr{
+					Err: &TraceErr{
+						Err:    innerErr,
+						Traces: innerTraces,
+					},
+				},
+			},
+		},
+		{
+			name: "with message",
+			err: proxyError{
+				TraceErr: &TraceErr{
+					Err: &TraceErr{
+						Err:     innerErr,
+						Traces:  innerTraces,
+						Message: "legacy user message",
+					},
+					Traces: caughtTraces,
+				},
+			},
+		},
+		{
+			name: "with messages",
+			err: proxyError{
+				TraceErr: &TraceErr{
+					Err: &TraceErr{
+						Err:      innerErr,
+						Traces:   innerTraces,
+						Messages: []string{"llama", "fox"},
+					},
+					Traces: caughtTraces,
+				},
+			},
+		},
+		{
+			name: "bare error",
+			err: proxyError{
+				TraceErr: &TraceErr{
+					Err:    errors.New("failure!"),
+					Traces: caughtTraces,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, OldProxyErrorDebugReport(test.err), test.err.DebugReport())
+		})
+	}
+}
+
+func TestTraceErrDebugReport(t *testing.T) {
+	traces := Traces{
+		{Path: "/a/b/c", Line: 109, Func: "abcd"},
+		{Path: "/q/p/r", Line: 120, Func: "lkjh"},
+	}
+	innerErr := &BadParameterError{Message: "bad param"}
+
+	tests := []struct {
+		name  string
+		error *TraceErr
+	}{
+		{
+			name: "basic",
+			error: &TraceErr{
+				Err:    innerErr,
+				Traces: traces,
+			},
+		},
+		{
+			name: "with fields",
+			error: &TraceErr{
+				Err:    innerErr,
+				Traces: traces,
+				Fields: map[string]interface{}{"key": "value"},
+			},
+		},
+		{
+			name: "with message",
+			error: &TraceErr{
+				Err:     innerErr,
+				Traces:  traces,
+				Message: "legacy user message",
+			},
+		},
+		{
+			name: "with messages",
+			error: &TraceErr{
+				Err:      innerErr,
+				Traces:   traces,
+				Messages: []string{"msg1", "msg2"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, OldTraceErrorDebugReport(test.error), test.error.DebugReport())
+		})
+	}
+}
 
 func TestEmpty(t *testing.T) {
 	assert.Equal(t, "", DebugReport(nil))

--- a/trace_test.go
+++ b/trace_test.go
@@ -190,6 +190,20 @@ func TestProxyErrorDebugReport(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "html special characters",
+			err: proxyError{
+				TraceErr: &TraceErr{
+					Err: &TraceErr{
+						Err:      &BadParameterError{Message: `a < b & c > d "e"`},
+						Traces:   innerTraces,
+						Fields:   map[string]interface{}{"k<ey": "v<al&ue>"},
+						Messages: []string{`<script>alert("xss")</script>`},
+					},
+					Traces: caughtTraces,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -239,6 +253,15 @@ func TestTraceErrDebugReport(t *testing.T) {
 				Err:      innerErr,
 				Traces:   traces,
 				Messages: []string{"msg1", "msg2"},
+			},
+		},
+		{
+			name: "html special characters",
+			error: &TraceErr{
+				Err:      &BadParameterError{Message: `a < b & c > d "e"`},
+				Traces:   traces,
+				Fields:   map[string]interface{}{"k<ey": "v<al&ue>"},
+				Messages: []string{`<script>alert("xss")</script>`},
 			},
 		},
 	}


### PR DESCRIPTION
Leveraging templates prevents dead code elimination for consumers of the trace library. The old method for generating the debug reports has been moved into trace_test.go and exposed via OldDebugReport functions so that the new handrolled reports can be validated against the templated version.