### PR TITLE
Make html escaping in DebugReports more exhaustive

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -557,12 +557,16 @@ func wrapProxy(err error) Error {
 	}
 }
 
+// htmlEscaper matches the escaping done in [html/template] for text and quoted
+// attributes, which is slightly more than what [html.EscapeString] does.
 var htmlEscaper = strings.NewReplacer(
+	"\x00", "\uFFFD",
+	`"`, "&#34;", // "&#34;" is shorter than "&quot;".
 	`&`, "&amp;",
 	`'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+	`+`, "&#43;",
 	`<`, "&lt;",
 	`>`, "&gt;",
-	`"`, "&#34;", // "&#34;" is shorter than "&quot;".
 )
 
 // DebugReport formats the underlying error for display

--- a/trace_test.go
+++ b/trace_test.go
@@ -195,7 +195,7 @@ func TestProxyErrorDebugReport(t *testing.T) {
 			err: proxyError{
 				TraceErr: &TraceErr{
 					Err: &TraceErr{
-						Err:      &BadParameterError{Message: `a < b & c > d "e"`},
+						Err:      &BadParameterError{Message: `a < b & c > d "e" + '` + "\x00" + `'`},
 						Traces:   innerTraces,
 						Fields:   map[string]interface{}{"k<ey": "v<al&ue>"},
 						Messages: []string{`<script>alert("xss")</script>`},
@@ -258,7 +258,7 @@ func TestTraceErrDebugReport(t *testing.T) {
 		{
 			name: "html special characters",
 			err: &TraceErr{
-				Err:      &BadParameterError{Message: `a < b & c > d "e"`},
+				Err:      &BadParameterError{Message: `a < b & c > d "e" + '` + "\x00" + `'`},
 				Traces:   traces,
 				Fields:   map[string]interface{}{"k<ey": "v<al&ue>"},
 				Messages: []string{`<script>alert("xss")</script>`},


### PR DESCRIPTION
This PR tweaks the manual HTML escaping from #118 since we missed two character replacements done by `html/template`, the plus sign and NUL.

The new test cases fail without the change and everything passes with the change.